### PR TITLE
z-tech/vsbw-mem-optimization

### DIFF
--- a/src/provers/time_prover.rs
+++ b/src/provers/time_prover.rs
@@ -7,41 +7,44 @@ use crate::provers::{evaluation_stream::EvaluationStream, prover::Prover};
 pub struct TimeProver<'a, F: Field> {
     pub claimed_sum: F,
     pub current_round: usize,
-    pub evaluations: Vec<F>,
+    pub evaluations: Option<Vec<F>>,
     pub evaluation_stream: Box<&'a dyn EvaluationStream<F>>, // Keep this for now, case we can do some small optimizations of first round etc
     pub num_variables: usize,
-    pub verifier_messages: Vec<F>,
-    pub verifier_message_hats: Vec<F>,
 }
 
 impl<'a, F: Field> TimeProver<'a, F> {
     pub fn new(evaluation_stream: Box<&'a dyn EvaluationStream<F>>) -> Self {
         let claimed_sum = evaluation_stream.get_claimed_sum();
         let num_variables = evaluation_stream.get_num_variables();
-        let hypercube_len = 2usize.pow(num_variables.try_into().unwrap());
-        let evaluations: Vec<F> = vec![F::ZERO; hypercube_len];
         Self {
             claimed_sum,
             current_round: 0,
-            evaluations,
+            evaluations: None,
             evaluation_stream,
             num_variables,
-            verifier_messages: Vec::<F>::with_capacity(num_variables),
-            verifier_message_hats: Vec::<F>::with_capacity(num_variables),
         }
     }
     fn num_free_variables(&self) -> usize {
         self.num_variables - self.current_round
     }
-    fn vsbw_evaluate(&self, use_stream: bool) -> (F, F) {
+    fn vsbw_evaluate(&self) -> (F, F) {
         let mut sum_0 = F::ZERO;
         let mut sum_1 = F::ZERO;
         let bitmask: usize = 1 << self.num_free_variables() - 1;
-        for i in 0..self.evaluations.len() {
+        let evaluations_len = match &self.evaluations {
+            Some(evaluations) => evaluations.len(),
+            None => 2usize.pow(
+                self.evaluation_stream
+                    .get_num_variables()
+                    .try_into()
+                    .unwrap(),
+            ),
+        };
+        for i in 0..evaluations_len {
             let is_set: bool = (i & bitmask) != 0;
-            let point_evaluation = match use_stream {
-                true => self.evaluation_stream.get_evaluation_from_index(i),
-                false => self.evaluations[i],
+            let point_evaluation = match &self.evaluations {
+                Some(evaluations) => evaluations[i],
+                None => self.evaluation_stream.get_evaluation_from_index(i),
             };
             match is_set {
                 false => sum_0 += point_evaluation,
@@ -50,28 +53,43 @@ impl<'a, F: Field> TimeProver<'a, F> {
         }
         (sum_0, sum_1)
     }
-    fn vsbw_reduce_evaluations(
-        &mut self,
-        verifier_message: F,
-        verifier_message_hat: F,
-        is_round_one: bool,
-    ) {
-        let half_size: usize = self.evaluations.len() / 2;
+    fn vsbw_reduce_evaluations(&mut self, verifier_message: F, verifier_message_hat: F) {
+        let mut evaluations = match &self.evaluations {
+            // all rounds after r=1 this table already exists
+            Some(evaluations) => evaluations.clone(),
+            // r=0 this function isn't called, r=1 we have to initialize this table and read in values from stream (2x size)
+            None => vec![
+                F::ZERO;
+                2usize.pow(
+                    self.evaluation_stream
+                        .get_num_variables()
+                        .try_into()
+                        .unwrap()
+                ) / 2
+            ],
+        };
+        let evaluations_len = match &self.evaluations {
+            // either we iterate through only half of the table
+            Some(evaluations) => evaluations.len() / 2,
+            // or we just initialized and we need to iterate through all of it, reading from stream (2x size) as we go
+            None => evaluations.len(),
+        };
         let setbit: usize = 1 << self.num_free_variables(); // we use this to index the second half of the last round's evaluations e.g 001 AND 101
-        for i0 in 0..half_size {
+        for i0 in 0..evaluations_len {
             let i1 = i0 | setbit;
-            let point_evaluation_i0 = match is_round_one {
-                true => self.evaluation_stream.get_evaluation_from_index(i0),
-                false => self.evaluations[i0],
+            let point_evaluation_i0 = match &self.evaluations {
+                None => self.evaluation_stream.get_evaluation_from_index(i0),
+                Some(evaluations) => evaluations[i0],
             };
-            let point_evaluation_i1 = match is_round_one {
-                true => self.evaluation_stream.get_evaluation_from_index(i1),
-                false => self.evaluations[i1],
+            let point_evaluation_i1 = match &self.evaluations {
+                None => self.evaluation_stream.get_evaluation_from_index(i1),
+                Some(evaluations) => evaluations[i1],
             };
-            self.evaluations[i0] =
+            evaluations[i0] =
                 point_evaluation_i0 * verifier_message_hat + point_evaluation_i1 * verifier_message;
         }
-        self.evaluations.truncate(half_size);
+        evaluations.truncate(evaluations_len);
+        self.evaluations = Some(evaluations.clone());
     }
 }
 
@@ -85,32 +103,17 @@ impl<'a, F: Field> Prover<F> for TimeProver<'a, F> {
             return None;
         }
 
-        // mem 1/2 optimization requires 3 cases:
-        let sums: (F, F);
-        match self.current_round {
-            0 => {
-                // no reduce, evaluate should be done from stream
-                sums = self.vsbw_evaluate(true);
-            }
-            1 => {
-                // reduce should be done from stream, evaluate as normal
-                self.vsbw_reduce_evaluations(
-                    verifier_message.unwrap(),
-                    F::ONE - verifier_message.unwrap(),
-                    true,
-                );
-                sums = self.vsbw_evaluate(false);
-            }
-            _ => {
-                // reduce as normal, evaluate as normal
-                self.vsbw_reduce_evaluations(
-                    verifier_message.unwrap(),
-                    F::ONE - verifier_message.unwrap(),
-                    false,
-                );
-                sums = self.vsbw_evaluate(false);
-            }
+        // If it's not the first round, reduce the evaluations table
+        if self.current_round != 0 {
+            // update the evaluations table by absorbing leftmost variable assigned to verifier_message
+            self.vsbw_reduce_evaluations(
+                verifier_message.unwrap(),
+                F::ONE - verifier_message.unwrap(),
+            )
         }
+
+        // evaluate using vsbw
+        let sums = self.vsbw_evaluate();
 
         // Increment the round counter
         self.current_round += 1;


### PR DESCRIPTION
What does this PR do?

- In vsbw
    - round=0 there is no call to reduce_evaluations and sums can be computed directly from the stream
    - round=1 evaluation table of size 1/2 evaluation_stream can be computed from the stream
    - round>=2 vsbw performs operations against the evaluation table as normal
- this optimization reduces overall memory usage by 1/2
- closes #12 