### PR TITLE
z-tech/prover-args-struct

### DIFF
--- a/src/proof.rs
+++ b/src/proof.rs
@@ -10,8 +10,8 @@ pub struct Sumcheck<F: Field> {
     pub is_accepted: bool,
 }
 
-impl<F: Field> Sumcheck<F> {
-    pub fn prove<P: Prover<F>, R: Rng>(prover: &mut P, rng: &mut R) -> Self {
+impl<'a, F: Field> Sumcheck<F> {
+    pub fn prove<P: Prover<'a, F>, R: Rng>(prover: &mut P, rng: &mut R) -> Self {
         // Initialize vectors to store prover and verifier messages
         let mut prover_messages: Vec<(F, F)> = Vec::with_capacity(prover.total_rounds());
         let mut verifier_messages: Vec<F> = Vec::with_capacity(prover.total_rounds());
@@ -64,7 +64,7 @@ mod tests {
     use super::Sumcheck;
     use crate::provers::{
         test_helpers::{BenchEvaluationStream, TestField},
-        BlendedProver, TimeProver,
+        BlendedProver, Prover, ProverArgs, TimeProver,
     };
 
     #[test]
@@ -72,9 +72,14 @@ mod tests {
         // take an evaluation stream
         let evaluation_stream: BenchEvaluationStream<TestField> = BenchEvaluationStream::new(20);
         // initialize the provers
-        let mut blended_k3_prover =
-            BlendedProver::<TestField>::new(Box::new(&evaluation_stream), 3);
-        let mut time_prover = TimeProver::<TestField>::new(Box::new(&evaluation_stream));
+        let mut blended_k3_prover = BlendedProver::<TestField>::new(ProverArgs {
+            stream: Box::new(&evaluation_stream),
+            num_stages: 3,
+        });
+        let mut time_prover = TimeProver::<TestField>::new(ProverArgs {
+            stream: Box::new(&evaluation_stream),
+            num_stages: TimeProver::<TestField>::DEFAULT_NUM_STAGES,
+        });
         // run them and get the transcript
         let blended_prover_transcript =
             Sumcheck::<TestField>::prove(&mut blended_k3_prover, &mut ark_std::test_rng());

--- a/src/provers/mod.rs
+++ b/src/provers/mod.rs
@@ -12,5 +12,6 @@ pub mod time_prover;
 
 pub use blended_prover::BlendedProver;
 pub use prover::Prover;
+pub use prover::ProverArgs;
 pub use space_prover::SpaceProver;
 pub use time_prover::TimeProver;

--- a/src/provers/prover.rs
+++ b/src/provers/prover.rs
@@ -1,6 +1,13 @@
 use ark_ff::Field;
 
-pub trait Prover<F: Field> {
+use crate::provers::evaluation_stream::EvaluationStream;
+pub struct ProverArgs<'a, F: Field> {
+    pub stream: Box<&'a dyn EvaluationStream<F>>,
+    pub num_stages: usize,
+}
+pub trait Prover<'a, F: Field> {
+    const DEFAULT_NUM_STAGES: usize;
+    fn new(prover_args: ProverArgs<'a, F>) -> Self;
     fn claimed_sum(&self) -> F;
     fn next_message(&mut self, verifier_message: Option<F>) -> Option<(F, F)>;
     fn total_rounds(&self) -> usize;

--- a/src/provers/test_helpers.rs
+++ b/src/provers/test_helpers.rs
@@ -16,7 +16,9 @@ pub struct TestFieldConfig;
 pub type TestField = Fp64<MontBackend<TestFieldConfig, 1>>;
 pub type TestPolynomial = multivariate::SparsePolynomial<TestField, SparseTerm>;
 
-pub fn run_boolean_sumcheck_test<F: Field + std::convert::From<i32>, P: Prover<F>>(mut prover: P) {
+pub fn run_boolean_sumcheck_test<'a, F: Field + std::convert::From<i32>, P: Prover<'a, F>>(
+    mut prover: P,
+) {
     // ZEROTH ROUND
     // all variables free
     // 000 = 0
@@ -78,7 +80,9 @@ pub fn run_boolean_sumcheck_test<F: Field + std::convert::From<i32>, P: Prover<F
     );
 }
 
-pub fn run_basic_sumcheck_test<F: Field + std::convert::From<i32>, P: Prover<F>>(mut prover: P) {
+pub fn run_basic_sumcheck_test<'a, F: Field + std::convert::From<i32>, P: Prover<'a, F>>(
+    mut prover: P,
+) {
     // FIRST ROUND x0 fixed to 3
     // 3,0,1 = 6
     // 3,0,0 = 6

--- a/sumcheck-benches/src/main.rs
+++ b/sumcheck-benches/src/main.rs
@@ -4,7 +4,10 @@ use ark_ff::{
     Field,
 };
 use space_efficient_sumcheck::{
-    provers::{test_helpers::BenchEvaluationStream, SpaceProver, TimeProver, BlendedProver},
+    provers::{
+        test_helpers::BenchEvaluationStream, BlendedProver, Prover, ProverArgs, SpaceProver,
+        TimeProver,
+    },
     Sumcheck,
 };
 use std::env;
@@ -121,16 +124,32 @@ fn run_bench_on_field<F: Field>(bench_args: BenchArgs) {
     let stream: BenchEvaluationStream<F> =
         BenchEvaluationStream::<F>::new(bench_args.num_variables);
     // switch on algorithm_label
+
     match bench_args.algorithm_label {
         AlgorithmLabel::CTY => {
-            Sumcheck::prove(&mut SpaceProver::<F>::new(Box::new(&stream)), &mut rng);
+            Sumcheck::prove(
+                &mut SpaceProver::<F>::new(ProverArgs {
+                    stream: Box::new(&stream),
+                    num_stages: SpaceProver::<F>::DEFAULT_NUM_STAGES,
+                }),
+                &mut rng,
+            );
         }
         AlgorithmLabel::VSBW => {
-            Sumcheck::prove(&mut TimeProver::<F>::new(Box::new(&stream)), &mut rng);
+            Sumcheck::prove(
+                &mut TimeProver::<F>::new(ProverArgs {
+                    stream: Box::new(&stream),
+                    num_stages: TimeProver::<F>::DEFAULT_NUM_STAGES,
+                }),
+                &mut rng,
+            );
         }
         AlgorithmLabel::Blended => {
             Sumcheck::prove(
-                &mut BlendedProver::<F>::new(Box::new(&stream), bench_args.stage_size),
+                &mut BlendedProver::<F>::new(ProverArgs {
+                    stream: Box::new(&stream),
+                    num_stages: bench_args.stage_size,
+                }),
                 &mut rng,
             );
         }


### PR DESCRIPTION
What is this PR?

- This PR changes the trait for Prover to include a new() function that takes a new struct ProverArgs {} with a lifetime as a parameter