### PR TITLE
z-tech/no-vec-bool-for-hypercube

### DIFF
--- a/src/provers/blended_prover.rs
+++ b/src/provers/blended_prover.rs
@@ -118,7 +118,7 @@ impl<'a, F: Field> BlendedProver<'a, F> {
         let j_prime = self.current_round - stage_start_index;
 
         // Iterate through b2_start indices using Hypercube::new(j_prime + 1)
-        for (b2_start_index, b2_start) in Hypercube::new(j_prime + 1).enumerate() {
+        for b2_start_index in 0..Hypercube::pow2(j_prime + 1) {
             // Calculate b2_start_index_0 and b2_start_index_1 for indexing partial_sums
             let shift_amount = if self.num_variables - stage_start_index < self.stage_size {
                 // this is the oddly sized last stage when k doesn't divide num_vars
@@ -138,7 +138,7 @@ impl<'a, F: Field> BlendedProver<'a, F> {
             let sum = right_value - left_value;
 
             // Match based on the last bit of b2_start
-            match *b2_start.last().unwrap() {
+            match b2_start_index & 1 == 1 {
                 false => sum_0 += self.lag_polys[b2_start_index] * sum,
                 true => sum_1 += self.lag_polys[b2_start_index] * sum,
             }

--- a/src/provers/hypercube.rs
+++ b/src/provers/hypercube.rs
@@ -1,4 +1,4 @@
-// this is basically a Vec<bool>, but we only need it for sizes < ~35 variables
+// basically, this emulates a Vec<bool> as an iterator wrapped over a usize
 #[derive(Debug, PartialEq)]
 pub struct HypercubeMember {
     last_index: usize,
@@ -31,13 +31,14 @@ impl Iterator for HypercubeMember {
     }
 }
 
-pub struct Hypercube2 {
+// this is an iterator that gives back HypercubeMember ^ above on each call to next
+pub struct Hypercube {
     num_variables: usize,
     last_member: Option<usize>,
     stop_member: usize, // stop at this number (exclusive)
 }
 
-impl Hypercube2 {
+impl Hypercube {
     pub fn new(num_variables: usize) -> Self {
         let stop_member = 1 << num_variables;
         Self {
@@ -51,7 +52,7 @@ impl Hypercube2 {
     }
 }
 
-impl Iterator for Hypercube2 {
+impl Iterator for Hypercube {
     type Item = HypercubeMember;
     fn next(&mut self) -> Option<Self::Item> {
         // a) Check if this is the first iteration
@@ -82,71 +83,9 @@ impl Iterator for Hypercube2 {
     }
 }
 
-pub struct Hypercube {
-    num_variables: usize,
-    last_member: Option<usize>,
-    last_point: Option<Vec<bool>>,
-    stop_member: usize, // stop at this number (exclusive)
-}
-
-impl Hypercube {
-    pub fn new(num_variables: usize) -> Self {
-        let stop_member = 1 << num_variables;
-        Self {
-            num_variables,
-            last_member: None,
-            last_point: None,
-            stop_member,
-        }
-    }
-    pub fn pow2(num_variables: usize) -> usize {
-        1 << num_variables
-    }
-}
-
-impl Iterator for Hypercube {
-    type Item = Vec<bool>;
-    fn next(&mut self) -> Option<Self::Item> {
-        // a) Check if this is the first iteration
-        if self.last_member == None {
-            // Initialize last member and last point
-            self.last_member = Some(0);
-            self.last_point = Some(vec![false; self.num_variables]);
-            // Return the cloned last point
-            return self.last_point.clone();
-        }
-
-        // b) Check if in the last iteration we finished iterating
-        let next_member = self.last_member.unwrap() + 1;
-        if next_member >= self.stop_member {
-            return None;
-        }
-
-        // c) Everything else, first get bit diff
-        let bit_diff = self.last_member.unwrap() ^ next_member;
-
-        //   Determine the shared prefix of the most significant bits
-        let low_index_of_prefix = (bit_diff + 1).trailing_zeros() as usize;
-
-        //   Iterate up to this prefix, setting bits correctly (half of the time this is only one bit!)
-        let mut last_point = self.last_point.clone().unwrap();
-        for bit_index in (0..low_index_of_prefix).rev() {
-            let target_bit: bool = (next_member & (1 << bit_index)) != 0;
-            last_point[self.num_variables - bit_index - 1] = target_bit;
-        }
-
-        //   Don't forget to increment the current member
-        self.last_member = Some(next_member);
-        self.last_point = Some(last_point);
-
-        //   Return the cloned last point
-        self.last_point.clone()
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::provers::hypercube::{Hypercube, Hypercube2, HypercubeMember};
+    use crate::provers::hypercube::{Hypercube, HypercubeMember};
 
     fn check_eq(given: HypercubeMember, expected: Vec<bool>) {
         // check each value in the vec
@@ -162,30 +101,30 @@ mod tests {
     #[test]
     fn basic() {
         // for 0, should return empty vec first call, none second call
-        let mut hypercube2_size_0 = Hypercube2::new(0);
-        check_eq(hypercube2_size_0.next().unwrap(), vec![]);
+        let mut hypercube_size_0 = Hypercube::new(0);
+        check_eq(hypercube_size_0.next().unwrap(), vec![]);
         // for 1, should return vec[false] first call, vec[true] second call and None third call
-        let mut hypercube2_size_1: Hypercube2 = Hypercube2::new(1);
-        check_eq(hypercube2_size_1.next().unwrap(), vec![false]);
-        check_eq(hypercube2_size_1.next().unwrap(), vec![true]);
-        assert_eq!(hypercube2_size_1.next(), None);
+        let mut hypercube_size_1: Hypercube = Hypercube::new(1);
+        check_eq(hypercube_size_1.next().unwrap(), vec![false]);
+        check_eq(hypercube_size_1.next().unwrap(), vec![true]);
+        assert_eq!(hypercube_size_1.next(), None);
         // so on for n=2
-        let mut hypercube2_size_2: Hypercube2 = Hypercube2::new(2);
-        check_eq(hypercube2_size_2.next().unwrap(), vec![false, false]);
-        check_eq(hypercube2_size_2.next().unwrap(), vec![false, true]);
-        check_eq(hypercube2_size_2.next().unwrap(), vec![true, false]);
-        check_eq(hypercube2_size_2.next().unwrap(), vec![true, true]);
-        assert_eq!(hypercube2_size_2.next(), None);
+        let mut hypercube_size_2: Hypercube = Hypercube::new(2);
+        check_eq(hypercube_size_2.next().unwrap(), vec![false, false]);
+        check_eq(hypercube_size_2.next().unwrap(), vec![false, true]);
+        check_eq(hypercube_size_2.next().unwrap(), vec![true, false]);
+        check_eq(hypercube_size_2.next().unwrap(), vec![true, true]);
+        assert_eq!(hypercube_size_2.next(), None);
         // so on for n=3
-        let mut hypercube2_size_3: Hypercube2 = Hypercube2::new(3);
-        check_eq(hypercube2_size_3.next().unwrap(), vec![false, false, false]);
-        check_eq(hypercube2_size_3.next().unwrap(), vec![false, false, true]);
-        check_eq(hypercube2_size_3.next().unwrap(), vec![false, true, false]);
-        check_eq(hypercube2_size_3.next().unwrap(), vec![false, true, true]);
-        check_eq(hypercube2_size_3.next().unwrap(), vec![true, false, false]);
-        check_eq(hypercube2_size_3.next().unwrap(), vec![true, false, true]);
-        check_eq(hypercube2_size_3.next().unwrap(), vec![true, true, false]);
-        check_eq(hypercube2_size_3.next().unwrap(), vec![true, true, true]);
-        assert_eq!(hypercube2_size_3.next(), None);
+        let mut hypercube_size_3: Hypercube = Hypercube::new(3);
+        check_eq(hypercube_size_3.next().unwrap(), vec![false, false, false]);
+        check_eq(hypercube_size_3.next().unwrap(), vec![false, false, true]);
+        check_eq(hypercube_size_3.next().unwrap(), vec![false, true, false]);
+        check_eq(hypercube_size_3.next().unwrap(), vec![false, true, true]);
+        check_eq(hypercube_size_3.next().unwrap(), vec![true, false, false]);
+        check_eq(hypercube_size_3.next().unwrap(), vec![true, false, true]);
+        check_eq(hypercube_size_3.next().unwrap(), vec![true, true, false]);
+        check_eq(hypercube_size_3.next().unwrap(), vec![true, true, true]);
+        assert_eq!(hypercube_size_3.next(), None);
     }
 }

--- a/src/provers/lagrange_polynomial.rs
+++ b/src/provers/lagrange_polynomial.rs
@@ -1,4 +1,4 @@
-use crate::provers::hypercube::Hypercube;
+use crate::provers::hypercube::{Hypercube, HypercubeMember};
 use ark_ff::Field;
 
 pub struct LagrangePolynomial<F: Field> {
@@ -35,24 +35,9 @@ impl<F: Field> LagrangePolynomial<F> {
             last_position: None,
         }
     }
-    pub fn lag_poly(x: Vec<F>, x_hat: Vec<F>, b: Vec<bool>) -> F {
+    pub fn lag_poly(x: Vec<F>, x_hat: Vec<F>, b: HypercubeMember) -> F {
         // Iterate over the zipped triple x, x_hat, and boolean hypercube vectors
-        x.iter().zip(x_hat.iter()).zip(b.iter()).fold(
-            // Initial the accumulation to F::ONE
-            F::ONE,
-            // Closure for the folding operation, taking accumulator and ((x_i, x_hat_i), b_i)
-            |acc, ((x_i, x_hat_i), b_i)| {
-                // Multiply the accumulator by either x_i or x_hat_i based on the boolean value b_i
-                acc * match b_i {
-                    true => *x_i,
-                    false => *x_hat_i,
-                }
-            },
-        )
-    }
-    pub fn lag_poly_2(x: Vec<F>, x_hat: Vec<F>, b: Vec<bool>) -> F {
-        // Iterate over the zipped triple x, x_hat, and boolean hypercube vectors
-        x.iter().zip(x_hat.iter()).zip(b.iter()).fold(
+        x.iter().zip(x_hat.iter()).zip(b).fold(
             // Initial the accumulation to F::ONE
             F::ONE,
             // Closure for the folding operation, taking accumulator and ((x_i, x_hat_i), b_i)
@@ -115,7 +100,10 @@ impl<F: Field> Iterator for LagrangePolynomial<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::provers::{lagrange_polynomial::LagrangePolynomial, test_helpers::TestField};
+    use crate::provers::{
+        hypercube::HypercubeMember, lagrange_polynomial::LagrangePolynomial,
+        test_helpers::TestField,
+    };
 
     #[test]
     fn lag_next_test() {
@@ -132,56 +120,56 @@ mod tests {
         let exp_0: TestField = LagrangePolynomial::lag_poly(
             messages.clone(),
             message_hats.clone(),
-            vec![false, false, false],
+            HypercubeMember::new(3, 0),
         );
         assert_eq!(st_0, exp_0);
         let st_1: TestField = bslp.next().unwrap();
         let exp_1: TestField = LagrangePolynomial::lag_poly(
             messages.clone(),
             message_hats.clone(),
-            vec![false, false, true],
+            HypercubeMember::new(3, 1),
         );
         assert_eq!(st_1, exp_1);
         let st_2: TestField = bslp.next().unwrap();
         let exp_2: TestField = LagrangePolynomial::lag_poly(
             messages.clone(),
             message_hats.clone(),
-            vec![false, true, false],
+            HypercubeMember::new(3, 2),
         );
         assert_eq!(st_2, exp_2);
         let st_3: TestField = bslp.next().unwrap();
         let exp_3: TestField = LagrangePolynomial::lag_poly(
             messages.clone(),
             message_hats.clone(),
-            vec![false, true, true],
+            HypercubeMember::new(3, 3),
         );
         assert_eq!(st_3, exp_3);
         let st_4: TestField = bslp.next().unwrap();
         let exp_4: TestField = LagrangePolynomial::lag_poly(
             messages.clone(),
             message_hats.clone(),
-            vec![true, false, false],
+            HypercubeMember::new(3, 4),
         );
         assert_eq!(st_4, exp_4);
         let st_5: TestField = bslp.next().unwrap();
         let exp_5: TestField = LagrangePolynomial::lag_poly(
             messages.clone(),
             message_hats.clone(),
-            vec![true, false, true],
+            HypercubeMember::new(3, 5),
         );
         assert_eq!(st_5, exp_5);
         let st_6: TestField = bslp.next().unwrap();
         let exp_6: TestField = LagrangePolynomial::lag_poly(
             messages.clone(),
             message_hats.clone(),
-            vec![true, true, false],
+            HypercubeMember::new(3, 6),
         );
         assert_eq!(st_6, exp_6);
         let st_7: TestField = bslp.next().unwrap();
         let exp_7: TestField = LagrangePolynomial::lag_poly(
             messages.clone(),
             message_hats.clone(),
-            vec![true, true, true],
+            HypercubeMember::new(3, 7),
         );
         assert_eq!(st_7, exp_7);
         assert_eq!(bslp.next(), None);


### PR DESCRIPTION
What does this PR do?

- implements Hypercube as an iterator wrapping a usize, eliminating the need to instantiate and work with Vec<bool>
- this falls under micro optimization