### PR TITLE
z-tech/improve-interface-for-num-stages

### DIFF
--- a/src/proof.rs
+++ b/src/proof.rs
@@ -64,7 +64,7 @@ mod tests {
     use super::Sumcheck;
     use crate::provers::{
         test_helpers::{BenchEvaluationStream, TestField},
-        BlendedProver, Prover, ProverArgs, TimeProver,
+        BlendedProver, Prover, ProverArgs, ProverArgsStageInfo, TimeProver,
     };
 
     #[test]
@@ -74,12 +74,11 @@ mod tests {
         // initialize the provers
         let mut blended_k3_prover = BlendedProver::<TestField>::new(ProverArgs {
             stream: Box::new(&evaluation_stream),
-            num_stages: 3,
+            stage_info: Some(ProverArgsStageInfo { num_stages: 3 }),
         });
-        let mut time_prover = TimeProver::<TestField>::new(ProverArgs {
-            stream: Box::new(&evaluation_stream),
-            num_stages: TimeProver::<TestField>::DEFAULT_NUM_STAGES,
-        });
+        let mut time_prover = TimeProver::<TestField>::new(
+            TimeProver::<TestField>::generate_default_args(Box::new(&evaluation_stream)),
+        );
         // run them and get the transcript
         let blended_prover_transcript =
             Sumcheck::<TestField>::prove(&mut blended_k3_prover, &mut ark_std::test_rng());

--- a/src/provers/mod.rs
+++ b/src/provers/mod.rs
@@ -11,7 +11,6 @@ pub mod space_prover;
 pub mod time_prover;
 
 pub use blended_prover::BlendedProver;
-pub use prover::Prover;
-pub use prover::ProverArgs;
+pub use prover::{Prover, ProverArgs, ProverArgsStageInfo};
 pub use space_prover::SpaceProver;
 pub use time_prover::TimeProver;

--- a/src/provers/prover.rs
+++ b/src/provers/prover.rs
@@ -1,12 +1,16 @@
 use ark_ff::Field;
 
 use crate::provers::evaluation_stream::EvaluationStream;
-pub struct ProverArgs<'a, F: Field> {
-    pub stream: Box<&'a dyn EvaluationStream<F>>,
+
+pub struct ProverArgsStageInfo {
     pub num_stages: usize,
 }
+pub struct ProverArgs<'a, F: Field> {
+    pub stream: Box<&'a dyn EvaluationStream<F>>,
+    pub stage_info: Option<ProverArgsStageInfo>,
+}
 pub trait Prover<'a, F: Field> {
-    const DEFAULT_NUM_STAGES: usize;
+    fn generate_default_args(stream: Box<&'a dyn EvaluationStream<F>>) -> ProverArgs<'a, F>;
     fn new(prover_args: ProverArgs<'a, F>) -> Self;
     fn claimed_sum(&self) -> F;
     fn next_message(&mut self, verifier_message: Option<F>) -> Option<(F, F)>;

--- a/sumcheck-benches/run_benches.sh
+++ b/sumcheck-benches/run_benches.sh
@@ -8,7 +8,7 @@
 # Then:
 #   kill <pid>
 
-algorithms="Blended2 VSBW Blended3 Blended4 Blended1 CTY"
+algorithms="Blended1 Blended2 VSBW Blended3 Blended4 CTY"
 fields="Field64 Field128 FieldBn254"
 
 for algorithm in $algorithms; do
@@ -33,7 +33,8 @@ for algorithm in $algorithms; do
                 "CTY") algorithm_label="CTY" ;;
                 *) ;;
             esac
-            output=`(gtime -v ./target/release/benches $algorithm_label $field $num_vars $stage_size) 2>&1`
+            # NOTE: if you're on mac you might install gnu-time and change next line to "gtime"
+            output=`(time -v ./target/release/benches $algorithm_label $field $num_vars $stage_size) 2>&1`
             user_time_seconds=$(echo "$output" | grep "User time (seconds):" | awk '{print $4}')
             user_time_ms=$(awk "BEGIN {printf \"%.0f\", $user_time_seconds * 1000}")
             ram_kilobytes=$(echo "$output" | grep "Maximum resident set size (kbytes)" | awk '{print $6}')

--- a/sumcheck-benches/src/main.rs
+++ b/sumcheck-benches/src/main.rs
@@ -5,8 +5,8 @@ use ark_ff::{
 };
 use space_efficient_sumcheck::{
     provers::{
-        test_helpers::BenchEvaluationStream, BlendedProver, Prover, ProverArgs, SpaceProver,
-        TimeProver,
+        test_helpers::BenchEvaluationStream, BlendedProver, Prover, ProverArgs,
+        ProverArgsStageInfo, SpaceProver, TimeProver,
     },
     Sumcheck,
 };
@@ -130,7 +130,7 @@ fn run_bench_on_field<F: Field>(bench_args: BenchArgs) {
             Sumcheck::prove(
                 &mut SpaceProver::<F>::new(ProverArgs {
                     stream: Box::new(&stream),
-                    num_stages: SpaceProver::<F>::DEFAULT_NUM_STAGES,
+                    stage_info: None,
                 }),
                 &mut rng,
             );
@@ -139,7 +139,7 @@ fn run_bench_on_field<F: Field>(bench_args: BenchArgs) {
             Sumcheck::prove(
                 &mut TimeProver::<F>::new(ProverArgs {
                     stream: Box::new(&stream),
-                    num_stages: TimeProver::<F>::DEFAULT_NUM_STAGES,
+                    stage_info: None,
                 }),
                 &mut rng,
             );
@@ -148,7 +148,9 @@ fn run_bench_on_field<F: Field>(bench_args: BenchArgs) {
             Sumcheck::prove(
                 &mut BlendedProver::<F>::new(ProverArgs {
                     stream: Box::new(&stream),
-                    num_stages: bench_args.stage_size,
+                    stage_info: Some(ProverArgsStageInfo {
+                        num_stages: bench_args.stage_size,
+                    }),
                 }),
                 &mut rng,
             );


### PR DESCRIPTION
What does this PR do?

- it's weird to have a concept of DEFAULT_STAGE_SIZE, or STAGE_SIZE for VSBW and CTY when they don't use this parameter... this might be confusing for the programmer
- this PR implements stage_info as an option on the ProverArgs struct
- it also implements a `generate_default_parameters()` function that can be called with just a stream irrespective of algorithm