### PR TITLE
z-tech/rm-box-from-prover-interface

### DIFF
--- a/src/proof.rs
+++ b/src/proof.rs
@@ -73,11 +73,11 @@ mod tests {
         let evaluation_stream: BenchEvaluationStream<TestField> = BenchEvaluationStream::new(20);
         // initialize the provers
         let mut blendy_k3_prover = BlendyProver::<TestField>::new(ProverArgs {
-            stream: Box::new(&evaluation_stream),
+            stream: &evaluation_stream,
             stage_info: Some(ProverArgsStageInfo { num_stages: 3 }),
         });
         let mut time_prover = TimeProver::<TestField>::new(
-            TimeProver::<TestField>::generate_default_args(Box::new(&evaluation_stream)),
+            TimeProver::<TestField>::generate_default_args(&evaluation_stream),
         );
         // run them and get the transcript
         let blendy_prover_transcript =

--- a/src/provers/blendy_prover.rs
+++ b/src/provers/blendy_prover.rs
@@ -11,7 +11,7 @@ use crate::provers::{
 pub struct BlendyProver<'a, F: Field> {
     pub claimed_sum: F,
     pub current_round: usize,
-    pub evaluation_stream: Box<&'a dyn EvaluationStream<F>>,
+    pub evaluation_stream: &'a dyn EvaluationStream<F>,
     pub num_stages: usize,
     pub num_variables: usize,
     pub verifier_messages: Vec<F>,
@@ -180,7 +180,7 @@ impl<'a, F: Field> Prover<'a, F> for BlendyProver<'a, F> {
         self.claimed_sum
     }
 
-    fn generate_default_args(stream: Box<&'a dyn EvaluationStream<F>>) -> ProverArgs<'a, F> {
+    fn generate_default_args(stream: &'a impl EvaluationStream<F>) -> ProverArgs<'a, F> {
         ProverArgs {
             stream,
             stage_info: Some(ProverArgsStageInfo {
@@ -262,15 +262,15 @@ mod tests {
         let evaluation_stream: BasicEvaluationStream<TestField> =
             BasicEvaluationStream::new(test_polynomial());
         run_boolean_sumcheck_test(BlendyProver::new(BlendyProver::generate_default_args(
-            Box::new(&evaluation_stream),
+            &evaluation_stream,
         )));
         // k=2
         run_basic_sumcheck_test(BlendyProver::new(BlendyProver::generate_default_args(
-            Box::new(&evaluation_stream),
+            &evaluation_stream,
         )));
         // k=1
         run_basic_sumcheck_test(BlendyProver::new(ProverArgs {
-            stream: Box::new(&evaluation_stream),
+            stream: &evaluation_stream,
             stage_info: Some(ProverArgsStageInfo { num_stages: 1 }),
         }));
     }

--- a/src/provers/prover.rs
+++ b/src/provers/prover.rs
@@ -6,11 +6,11 @@ pub struct ProverArgsStageInfo {
     pub num_stages: usize,
 }
 pub struct ProverArgs<'a, F: Field> {
-    pub stream: Box<&'a dyn EvaluationStream<F>>,
+    pub stream: &'a dyn EvaluationStream<F>,
     pub stage_info: Option<ProverArgsStageInfo>,
 }
 pub trait Prover<'a, F: Field> {
-    fn generate_default_args(stream: Box<&'a dyn EvaluationStream<F>>) -> ProverArgs<'a, F>;
+    fn generate_default_args(stream: &'a impl EvaluationStream<F>) -> ProverArgs<'a, F>;
     fn new(prover_args: ProverArgs<'a, F>) -> Self;
     fn claimed_sum(&self) -> F;
     fn next_message(&mut self, verifier_message: Option<F>) -> Option<(F, F)>;

--- a/src/provers/space_prover.rs
+++ b/src/provers/space_prover.rs
@@ -10,7 +10,7 @@ use crate::provers::{
 pub struct SpaceProver<'a, F: Field> {
     pub claimed_sum: F,
     pub current_round: usize,
-    pub evaluation_stream: Box<&'a dyn EvaluationStream<F>>,
+    pub evaluation_stream: &'a dyn EvaluationStream<F>,
     pub num_variables: usize,
     pub verifier_messages: Vec<F>,
     pub verifier_message_hats: Vec<F>,
@@ -71,7 +71,7 @@ impl<'a, F: Field> Prover<'a, F> for SpaceProver<'a, F> {
         self.claimed_sum
     }
 
-    fn generate_default_args(stream: Box<&'a dyn EvaluationStream<F>>) -> ProverArgs<'a, F> {
+    fn generate_default_args(stream: &'a impl EvaluationStream<F>) -> ProverArgs<'a, F> {
         ProverArgs {
             stream,
             stage_info: None,
@@ -133,10 +133,10 @@ mod tests {
         let evaluation_stream: BasicEvaluationStream<TestField> =
             BasicEvaluationStream::new(test_polynomial());
         run_boolean_sumcheck_test(SpaceProver::new(SpaceProver::generate_default_args(
-            Box::new(&evaluation_stream),
+            &evaluation_stream,
         )));
         run_basic_sumcheck_test(SpaceProver::new(SpaceProver::generate_default_args(
-            Box::new(&evaluation_stream),
+            &evaluation_stream,
         )));
     }
 }

--- a/src/provers/time_prover.rs
+++ b/src/provers/time_prover.rs
@@ -10,7 +10,7 @@ pub struct TimeProver<'a, F: Field> {
     pub claimed_sum: F,
     pub current_round: usize,
     pub evaluations: Option<Vec<F>>,
-    pub evaluation_stream: Box<&'a dyn EvaluationStream<F>>, // Keep this for now, case we can do some small optimizations of first round etc
+    pub evaluation_stream: &'a dyn EvaluationStream<F>, // Keep this for now, case we can do some small optimizations of first round etc
     pub num_variables: usize,
 }
 
@@ -109,7 +109,7 @@ impl<'a, F: Field> Prover<'a, F> for TimeProver<'a, F> {
         self.claimed_sum
     }
 
-    fn generate_default_args(stream: Box<&'a dyn EvaluationStream<F>>) -> ProverArgs<'a, F> {
+    fn generate_default_args(stream: &'a impl EvaluationStream<F>) -> ProverArgs<'a, F> {
         ProverArgs {
             stream,
             stage_info: None,
@@ -170,13 +170,15 @@ mod tests {
 
     #[test]
     fn sumcheck() {
-        let evaluation_stream: BasicEvaluationStream<TestField> =
+        let evaluation_stream_0: BasicEvaluationStream<TestField> =
             BasicEvaluationStream::new(test_polynomial());
         run_boolean_sumcheck_test(TimeProver::new(TimeProver::generate_default_args(
-            Box::new(&evaluation_stream),
+            &evaluation_stream_0,
         )));
+        let evaluation_stream_1: BasicEvaluationStream<TestField> =
+            BasicEvaluationStream::new(test_polynomial());
         run_basic_sumcheck_test(TimeProver::new(TimeProver::generate_default_args(
-            Box::new(&evaluation_stream),
+            &evaluation_stream_1,
         )));
     }
 }

--- a/sumcheck-benches/run_benches.sh
+++ b/sumcheck-benches/run_benches.sh
@@ -34,7 +34,7 @@ for algorithm in $algorithms; do
                 *) ;;
             esac
             # NOTE: if you're on mac you might install gnu-time and change next line to "gtime"
-            output=`(gtime -v ./target/release/benches $algorithm_label $field $num_vars $stage_size) 2>&1`
+            output=`(time -v ./target/release/benches $algorithm_label $field $num_vars $stage_size) 2>&1`
             user_time_seconds=$(echo "$output" | grep "User time (seconds):" | awk '{print $4}')
             user_time_ms=$(awk "BEGIN {printf \"%.0f\", $user_time_seconds * 1000}")
             ram_kilobytes=$(echo "$output" | grep "Maximum resident set size (kbytes)" | awk '{print $6}')

--- a/sumcheck-benches/src/main.rs
+++ b/sumcheck-benches/src/main.rs
@@ -5,8 +5,8 @@ use ark_ff::{
 };
 use space_efficient_sumcheck::{
     provers::{
-        test_helpers::BenchEvaluationStream, BlendyProver, Prover, ProverArgs,
-        ProverArgsStageInfo, SpaceProver, TimeProver,
+        test_helpers::BenchEvaluationStream, BlendyProver, Prover, ProverArgs, ProverArgsStageInfo,
+        SpaceProver, TimeProver,
     },
     Sumcheck,
 };
@@ -129,7 +129,7 @@ fn run_bench_on_field<F: Field>(bench_args: BenchArgs) {
         AlgorithmLabel::CTY => {
             Sumcheck::prove(
                 &mut SpaceProver::<F>::new(ProverArgs {
-                    stream: Box::new(&stream),
+                    stream: &stream,
                     stage_info: None,
                 }),
                 &mut rng,
@@ -138,7 +138,7 @@ fn run_bench_on_field<F: Field>(bench_args: BenchArgs) {
         AlgorithmLabel::VSBW => {
             Sumcheck::prove(
                 &mut TimeProver::<F>::new(ProverArgs {
-                    stream: Box::new(&stream),
+                    stream: &stream,
                     stage_info: None,
                 }),
                 &mut rng,
@@ -147,7 +147,7 @@ fn run_bench_on_field<F: Field>(bench_args: BenchArgs) {
         AlgorithmLabel::Blendy => {
             Sumcheck::prove(
                 &mut BlendyProver::<F>::new(ProverArgs {
-                    stream: Box::new(&stream),
+                    stream: &stream,
                     stage_info: Some(ProverArgsStageInfo {
                         num_stages: bench_args.stage_size,
                     }),


### PR DESCRIPTION
What does this PR do?

- We found through some simple benchmarking that `impl` _can be_ more performant than `box` in specific scenarios, so we update the prover interface in favor of impl