### PR TITLE
Avoid using dynamic dispatch (dyn) and heap allocation (Box) 

### DIFF
--- a/src/proof.rs
+++ b/src/proof.rs
@@ -73,11 +73,11 @@ mod tests {
         let evaluation_stream: BenchEvaluationStream<TestField> = BenchEvaluationStream::new(20);
         // initialize the provers
         let mut blendy_k3_prover = BlendyProver::<TestField>::new(ProverArgs {
-            stream: Box::new(&evaluation_stream),
+            stream: &evaluation_stream,
             stage_info: Some(ProverArgsStageInfo { num_stages: 3 }),
         });
         let mut time_prover = TimeProver::<TestField>::new(
-            TimeProver::<TestField>::generate_default_args(Box::new(&evaluation_stream)),
+            TimeProver::<TestField>::generate_default_args(&evaluation_stream),
         );
         // run them and get the transcript
         let blendy_prover_transcript =

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,17 +1,18 @@
 use ark_ff::Field;
-use ark_std::{rand::Rng, vec::Vec};
+use ark_std::{marker::PhantomData, rand::Rng, vec::Vec};
 
-use crate::provers::Prover;
+use crate::provers::{evaluation_stream::EvaluationStream, Prover};
 
 #[derive(Debug)]
-pub struct Sumcheck<F: Field> {
+pub struct Sumcheck<F: Field, S: EvaluationStream<F>> {
     pub prover_messages: Vec<(F, F)>,
     pub verifier_messages: Vec<F>,
     pub is_accepted: bool,
+    _phantom: PhantomData<S>,
 }
 
-impl<'a, F: Field> Sumcheck<F> {
-    pub fn prove<P: Prover<'a, F>, R: Rng>(prover: &mut P, rng: &mut R) -> Self {
+impl<'a, F: Field, S: EvaluationStream<F>> Sumcheck<F, S> {
+    pub fn prove<P: Prover<'a, F, S>, R: Rng>(prover: &mut P, rng: &mut R) -> Self {
         // Initialize vectors to store prover and verifier messages
         let mut prover_messages: Vec<(F, F)> = Vec::with_capacity(prover.total_rounds());
         let mut verifier_messages: Vec<F> = Vec::with_capacity(prover.total_rounds());
@@ -55,12 +56,15 @@ impl<'a, F: Field> Sumcheck<F> {
             prover_messages,
             verifier_messages,
             is_accepted,
+            _phantom: PhantomData,
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::marker::PhantomData;
+
     use super::Sumcheck;
     use crate::provers::{
         test_helpers::{BenchEvaluationStream, TestField},
@@ -72,18 +76,29 @@ mod tests {
         // take an evaluation stream
         let evaluation_stream: BenchEvaluationStream<TestField> = BenchEvaluationStream::new(20);
         // initialize the provers
-        let mut blendy_k3_prover = BlendyProver::<TestField>::new(ProverArgs {
-            stream: &evaluation_stream,
-            stage_info: Some(ProverArgsStageInfo { num_stages: 3 }),
-        });
-        let mut time_prover = TimeProver::<TestField>::new(
-            TimeProver::<TestField>::generate_default_args(&evaluation_stream),
-        );
+        let mut blendy_k3_prover =
+            BlendyProver::<TestField, BenchEvaluationStream<TestField>>::new(ProverArgs {
+                stream: &evaluation_stream,
+                stage_info: Some(ProverArgsStageInfo { num_stages: 3 }),
+                _phantom: PhantomData,
+            });
+        let mut time_prover =
+            TimeProver::<TestField, BenchEvaluationStream<TestField>>::new(TimeProver::<
+                TestField,
+                BenchEvaluationStream<TestField>,
+            >::generate_default_args(
+                &evaluation_stream
+            ));
         // run them and get the transcript
         let blendy_prover_transcript =
-            Sumcheck::<TestField>::prove(&mut blendy_k3_prover, &mut ark_std::test_rng());
-        let time_prover_transcript =
-            Sumcheck::<TestField>::prove(&mut time_prover, &mut ark_std::test_rng());
+            Sumcheck::<TestField, BenchEvaluationStream<TestField>>::prove(
+                &mut blendy_k3_prover,
+                &mut ark_std::test_rng(),
+            );
+        let time_prover_transcript = Sumcheck::<TestField, BenchEvaluationStream<TestField>>::prove(
+            &mut time_prover,
+            &mut ark_std::test_rng(),
+        );
         // ensure the transcript is identical
         assert_eq!(
             time_prover_transcript.prover_messages,

--- a/src/provers/blendy_prover.rs
+++ b/src/provers/blendy_prover.rs
@@ -11,7 +11,7 @@ use crate::provers::{
 pub struct BlendyProver<'a, F: Field> {
     pub claimed_sum: F,
     pub current_round: usize,
-    pub evaluation_stream: Box<&'a dyn EvaluationStream<F>>,
+    pub evaluation_stream: &'a dyn EvaluationStream<F>,
     pub num_stages: usize,
     pub num_variables: usize,
     pub verifier_messages: Vec<F>,
@@ -180,7 +180,7 @@ impl<'a, F: Field> Prover<'a, F> for BlendyProver<'a, F> {
         self.claimed_sum
     }
 
-    fn generate_default_args(stream: Box<&'a dyn EvaluationStream<F>>) -> ProverArgs<'a, F> {
+    fn generate_default_args(stream: &'a impl EvaluationStream<F>) -> ProverArgs<'a, F> {
         ProverArgs {
             stream,
             stage_info: Some(ProverArgsStageInfo {
@@ -262,15 +262,15 @@ mod tests {
         let evaluation_stream: BasicEvaluationStream<TestField> =
             BasicEvaluationStream::new(test_polynomial());
         run_boolean_sumcheck_test(BlendyProver::new(BlendyProver::generate_default_args(
-            Box::new(&evaluation_stream),
+            &evaluation_stream,
         )));
         // k=2
         run_basic_sumcheck_test(BlendyProver::new(BlendyProver::generate_default_args(
-            Box::new(&evaluation_stream),
+            &evaluation_stream,
         )));
         // k=1
         run_basic_sumcheck_test(BlendyProver::new(ProverArgs {
-            stream: Box::new(&evaluation_stream),
+            stream: &evaluation_stream,
             stage_info: Some(ProverArgsStageInfo { num_stages: 1 }),
         }));
     }

--- a/src/provers/blendy_prover.rs
+++ b/src/provers/blendy_prover.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use ark_ff::Field;
 use ark_std::vec::Vec;
 
@@ -8,10 +10,10 @@ use crate::provers::{
     prover::{Prover, ProverArgs, ProverArgsStageInfo},
 };
 
-pub struct BlendyProver<'a, F: Field> {
+pub struct BlendyProver<'a, F: Field, S: EvaluationStream<F>> {
     pub claimed_sum: F,
     pub current_round: usize,
-    pub evaluation_stream: &'a dyn EvaluationStream<F>,
+    pub evaluation_stream: &'a S,
     pub num_stages: usize,
     pub num_variables: usize,
     pub verifier_messages: Vec<F>,
@@ -22,7 +24,7 @@ pub struct BlendyProver<'a, F: Field> {
     pub stage_size: usize,
 }
 
-impl<'a, F: Field> BlendyProver<'a, F> {
+impl<'a, F: Field, S: EvaluationStream<F>> BlendyProver<'a, F, S> {
     const DEFAULT_NUM_STAGES: usize = 2;
 
     fn shift_and_one_fill(num: usize, shift_amount: usize) -> usize {
@@ -175,21 +177,22 @@ impl<'a, F: Field> BlendyProver<'a, F> {
     }
 }
 
-impl<'a, F: Field> Prover<'a, F> for BlendyProver<'a, F> {
+impl<'a, F: Field, S: EvaluationStream<F>> Prover<'a, F, S> for BlendyProver<'a, F, S> {
     fn claimed_sum(&self) -> F {
         self.claimed_sum
     }
 
-    fn generate_default_args(stream: &'a impl EvaluationStream<F>) -> ProverArgs<'a, F> {
+    fn generate_default_args(stream: &'a S) -> ProverArgs<'a, F, S> {
         ProverArgs {
             stream,
             stage_info: Some(ProverArgsStageInfo {
-                num_stages: BlendyProver::<F>::DEFAULT_NUM_STAGES,
+                num_stages: BlendyProver::<F, S>::DEFAULT_NUM_STAGES,
             }),
+            _phantom: PhantomData,
         }
     }
 
-    fn new(prover_args: ProverArgs<'a, F>) -> Self {
+    fn new(prover_args: ProverArgs<'a, F, S>) -> Self {
         let claimed_sum: F = prover_args.stream.get_claimed_sum();
         let num_variables: usize = prover_args.stream.get_num_variables();
         let num_stages: usize = prover_args.stage_info.unwrap().num_stages;
@@ -248,6 +251,8 @@ impl<'a, F: Field> Prover<'a, F> for BlendyProver<'a, F> {
 
 #[cfg(test)]
 mod tests {
+    use std::marker::PhantomData;
+
     use crate::provers::{
         prover::{Prover, ProverArgs, ProverArgsStageInfo},
         test_helpers::{
@@ -272,6 +277,7 @@ mod tests {
         run_basic_sumcheck_test(BlendyProver::new(ProverArgs {
             stream: &evaluation_stream,
             stage_info: Some(ProverArgsStageInfo { num_stages: 1 }),
+            _phantom: PhantomData,
         }));
     }
 }

--- a/src/provers/prover.rs
+++ b/src/provers/prover.rs
@@ -1,17 +1,19 @@
 use ark_ff::Field;
+use ark_std::marker::PhantomData;
 
 use crate::provers::evaluation_stream::EvaluationStream;
 
 pub struct ProverArgsStageInfo {
     pub num_stages: usize,
 }
-pub struct ProverArgs<'a, F: Field> {
-    pub stream: &'a dyn EvaluationStream<F>,
+pub struct ProverArgs<'a, F: Field, S: EvaluationStream<F>> {
+    pub stream: &'a S,
     pub stage_info: Option<ProverArgsStageInfo>,
+    pub _phantom: PhantomData<F>,
 }
-pub trait Prover<'a, F: Field> {
-    fn generate_default_args(stream: &'a impl EvaluationStream<F>) -> ProverArgs<'a, F>;
-    fn new(prover_args: ProverArgs<'a, F>) -> Self;
+pub trait Prover<'a, F: Field, S: EvaluationStream<F>> {
+    fn generate_default_args(stream: &'a S) -> ProverArgs<'a, F, S>;
+    fn new(prover_args: ProverArgs<'a, F, S>) -> Self;
     fn claimed_sum(&self) -> F;
     fn next_message(&mut self, verifier_message: Option<F>) -> Option<(F, F)>;
     fn total_rounds(&self) -> usize;

--- a/src/provers/prover.rs
+++ b/src/provers/prover.rs
@@ -6,11 +6,11 @@ pub struct ProverArgsStageInfo {
     pub num_stages: usize,
 }
 pub struct ProverArgs<'a, F: Field> {
-    pub stream: Box<&'a dyn EvaluationStream<F>>,
+    pub stream: &'a dyn EvaluationStream<F>,
     pub stage_info: Option<ProverArgsStageInfo>,
 }
 pub trait Prover<'a, F: Field> {
-    fn generate_default_args(stream: Box<&'a dyn EvaluationStream<F>>) -> ProverArgs<'a, F>;
+    fn generate_default_args(stream: &'a impl EvaluationStream<F>) -> ProverArgs<'a, F>;
     fn new(prover_args: ProverArgs<'a, F>) -> Self;
     fn claimed_sum(&self) -> F;
     fn next_message(&mut self, verifier_message: Option<F>) -> Option<(F, F)>;

--- a/src/provers/space_prover.rs
+++ b/src/provers/space_prover.rs
@@ -10,7 +10,7 @@ use crate::provers::{
 pub struct SpaceProver<'a, F: Field> {
     pub claimed_sum: F,
     pub current_round: usize,
-    pub evaluation_stream: Box<&'a dyn EvaluationStream<F>>,
+    pub evaluation_stream: &'a dyn EvaluationStream<F>,
     pub num_variables: usize,
     pub verifier_messages: Vec<F>,
     pub verifier_message_hats: Vec<F>,
@@ -71,7 +71,7 @@ impl<'a, F: Field> Prover<'a, F> for SpaceProver<'a, F> {
         self.claimed_sum
     }
 
-    fn generate_default_args(stream: Box<&'a dyn EvaluationStream<F>>) -> ProverArgs<'a, F> {
+    fn generate_default_args(stream: &'a impl EvaluationStream<F>) -> ProverArgs<'a, F> {
         ProverArgs {
             stream,
             stage_info: None,
@@ -133,10 +133,10 @@ mod tests {
         let evaluation_stream: BasicEvaluationStream<TestField> =
             BasicEvaluationStream::new(test_polynomial());
         run_boolean_sumcheck_test(SpaceProver::new(SpaceProver::generate_default_args(
-            Box::new(&evaluation_stream),
+            &evaluation_stream,
         )));
         run_basic_sumcheck_test(SpaceProver::new(SpaceProver::generate_default_args(
-            Box::new(&evaluation_stream),
+            &evaluation_stream,
         )));
     }
 }

--- a/src/provers/test_helpers.rs
+++ b/src/provers/test_helpers.rs
@@ -20,7 +20,12 @@ pub struct TestFieldConfig;
 pub type TestField = Fp64<MontBackend<TestFieldConfig, 1>>;
 pub type TestPolynomial = multivariate::SparsePolynomial<TestField, SparseTerm>;
 
-pub fn run_boolean_sumcheck_test<'a, F: Field + std::convert::From<i32>, P: Prover<'a, F>>(
+pub fn run_boolean_sumcheck_test<
+    'a,
+    F: Field + std::convert::From<i32>,
+    S: EvaluationStream<F>,
+    P: Prover<'a, F, S>,
+>(
     mut prover: P,
 ) {
     // ZEROTH ROUND
@@ -84,7 +89,12 @@ pub fn run_boolean_sumcheck_test<'a, F: Field + std::convert::From<i32>, P: Prov
     );
 }
 
-pub fn run_basic_sumcheck_test<'a, F: Field + std::convert::From<i32>, P: Prover<'a, F>>(
+pub fn run_basic_sumcheck_test<
+    'a,
+    F: Field + std::convert::From<i32>,
+    S: EvaluationStream<F>,
+    P: Prover<'a, F, S>,
+>(
     mut prover: P,
 ) {
     // FIRST ROUND x0 fixed to 3

--- a/src/provers/time_prover.rs
+++ b/src/provers/time_prover.rs
@@ -10,7 +10,7 @@ pub struct TimeProver<'a, F: Field> {
     pub claimed_sum: F,
     pub current_round: usize,
     pub evaluations: Option<Vec<F>>,
-    pub evaluation_stream: Box<&'a dyn EvaluationStream<F>>, // Keep this for now, case we can do some small optimizations of first round etc
+    pub evaluation_stream: &'a dyn EvaluationStream<F>, // Keep this for now, case we can do some small optimizations of first round etc
     pub num_variables: usize,
 }
 
@@ -109,7 +109,7 @@ impl<'a, F: Field> Prover<'a, F> for TimeProver<'a, F> {
         self.claimed_sum
     }
 
-    fn generate_default_args(stream: Box<&'a dyn EvaluationStream<F>>) -> ProverArgs<'a, F> {
+    fn generate_default_args(stream: &'a impl EvaluationStream<F>) -> ProverArgs<'a, F> {
         ProverArgs {
             stream,
             stage_info: None,
@@ -170,13 +170,15 @@ mod tests {
 
     #[test]
     fn sumcheck() {
-        let evaluation_stream: BasicEvaluationStream<TestField> =
+        let evaluation_stream_0: BasicEvaluationStream<TestField> =
             BasicEvaluationStream::new(test_polynomial());
         run_boolean_sumcheck_test(TimeProver::new(TimeProver::generate_default_args(
-            Box::new(&evaluation_stream),
+            &evaluation_stream_0,
         )));
+        let evaluation_stream_1: BasicEvaluationStream<TestField> =
+            BasicEvaluationStream::new(test_polynomial());
         run_basic_sumcheck_test(TimeProver::new(TimeProver::generate_default_args(
-            Box::new(&evaluation_stream),
+            &evaluation_stream_1,
         )));
     }
 }

--- a/sumcheck-benches/run_benches.sh
+++ b/sumcheck-benches/run_benches.sh
@@ -34,7 +34,7 @@ for algorithm in $algorithms; do
                 *) ;;
             esac
             # NOTE: if you're on mac you might install gnu-time and change next line to "gtime"
-            output=`(gtime -v ./target/release/benches $algorithm_label $field $num_vars $stage_size) 2>&1`
+            output=`(time -v ./target/release/benches $algorithm_label $field $num_vars $stage_size) 2>&1`
             user_time_seconds=$(echo "$output" | grep "User time (seconds):" | awk '{print $4}')
             user_time_ms=$(awk "BEGIN {printf \"%.0f\", $user_time_seconds * 1000}")
             ram_kilobytes=$(echo "$output" | grep "Maximum resident set size (kbytes)" | awk '{print $6}')

--- a/sumcheck-benches/src/main.rs
+++ b/sumcheck-benches/src/main.rs
@@ -5,8 +5,8 @@ use ark_ff::{
 };
 use space_efficient_sumcheck::{
     provers::{
-        test_helpers::BenchEvaluationStream, BlendyProver, Prover, ProverArgs,
-        ProverArgsStageInfo, SpaceProver, TimeProver,
+        test_helpers::BenchEvaluationStream, BlendyProver, Prover, ProverArgs, ProverArgsStageInfo,
+        SpaceProver, TimeProver,
     },
     Sumcheck,
 };
@@ -129,7 +129,7 @@ fn run_bench_on_field<F: Field>(bench_args: BenchArgs) {
         AlgorithmLabel::CTY => {
             Sumcheck::prove(
                 &mut SpaceProver::<F>::new(ProverArgs {
-                    stream: Box::new(&stream),
+                    stream: &stream,
                     stage_info: None,
                 }),
                 &mut rng,
@@ -138,7 +138,7 @@ fn run_bench_on_field<F: Field>(bench_args: BenchArgs) {
         AlgorithmLabel::VSBW => {
             Sumcheck::prove(
                 &mut TimeProver::<F>::new(ProverArgs {
-                    stream: Box::new(&stream),
+                    stream: &stream,
                     stage_info: None,
                 }),
                 &mut rng,
@@ -147,7 +147,7 @@ fn run_bench_on_field<F: Field>(bench_args: BenchArgs) {
         AlgorithmLabel::Blendy => {
             Sumcheck::prove(
                 &mut BlendyProver::<F>::new(ProverArgs {
-                    stream: Box::new(&stream),
+                    stream: &stream,
                     stage_info: Some(ProverArgsStageInfo {
                         num_stages: bench_args.stage_size,
                     }),

--- a/sumcheck-benches/src/main.rs
+++ b/sumcheck-benches/src/main.rs
@@ -3,6 +3,7 @@ use ark_ff::{
     fields::{Fp128, Fp64, MontBackend, MontConfig},
     Field,
 };
+use ark_std::marker::PhantomData;
 use space_efficient_sumcheck::{
     provers::{
         test_helpers::BenchEvaluationStream, BlendyProver, Prover, ProverArgs, ProverArgsStageInfo,
@@ -128,29 +129,32 @@ fn run_bench_on_field<F: Field>(bench_args: BenchArgs) {
     match bench_args.algorithm_label {
         AlgorithmLabel::CTY => {
             Sumcheck::prove(
-                &mut SpaceProver::<F>::new(ProverArgs {
+                &mut SpaceProver::<F, BenchEvaluationStream<F>>::new(ProverArgs {
                     stream: &stream,
                     stage_info: None,
+                    _phantom: PhantomData,
                 }),
                 &mut rng,
             );
         }
         AlgorithmLabel::VSBW => {
             Sumcheck::prove(
-                &mut TimeProver::<F>::new(ProverArgs {
+                &mut TimeProver::<F, BenchEvaluationStream<F>>::new(ProverArgs {
                     stream: &stream,
                     stage_info: None,
+                    _phantom: PhantomData,
                 }),
                 &mut rng,
             );
         }
         AlgorithmLabel::Blendy => {
             Sumcheck::prove(
-                &mut BlendyProver::<F>::new(ProverArgs {
+                &mut BlendyProver::<F, BenchEvaluationStream<F>>::new(ProverArgs {
                     stream: &stream,
                     stage_info: Some(ProverArgsStageInfo {
                         num_stages: bench_args.stage_size,
                     }),
+                    _phantom: PhantomData,
                 }),
                 &mut rng,
             );


### PR DESCRIPTION
What does this PR do?

- we find in some cases Box(dyn) leads to lower performance (see issue #51 ) so we want to avoid this when easy to do so