### PR TITLE
z-tech/rm-claim-from-stream

### DIFF
--- a/src/multilinear_product/sumcheck.rs
+++ b/src/multilinear_product/sumcheck.rs
@@ -80,41 +80,45 @@ mod tests {
     use crate::{
         multilinear_product::{BlendyProductProver, BlendyProductProverConfig, TimeProductProver},
         prover::{ProductProverConfig, Prover},
-        tests::{BenchStream, F19},
+        streams::Stream,
+        tests::{BenchStream, F64},
     };
 
     #[test]
     fn algorithm_consistency() {
         const NUM_VARIABLES: usize = 16;
         // take an evaluation stream
-        let evaluation_stream: BenchStream<F19> = BenchStream::new(NUM_VARIABLES);
-        let claim = F19::from(11);
+        let evaluation_stream: BenchStream<F64> = BenchStream::new(NUM_VARIABLES);
+        let mut claim = F64::from(0);
+        for i in 0..2usize.pow(NUM_VARIABLES as u32) {
+            claim += evaluation_stream.evaluation(i) * evaluation_stream.evaluation(i);
+        }
         // initialize the provers
         let mut blendy_k2_prover =
-            BlendyProductProver::<F19, BenchStream<F19>>::new(BlendyProductProverConfig::new(
+            BlendyProductProver::<F64, BenchStream<F64>>::new(BlendyProductProverConfig::new(
                 claim,
                 2,
                 NUM_VARIABLES,
                 evaluation_stream.clone(),
                 evaluation_stream.clone(),
             ));
-        let blendy_prover_transcript = ProductSumcheck::<F19>::prove::<
-            BenchStream<F19>,
-            BlendyProductProver<F19, BenchStream<F19>>,
+        let blendy_prover_transcript = ProductSumcheck::<F64>::prove::<
+            BenchStream<F64>,
+            BlendyProductProver<F64, BenchStream<F64>>,
         >(&mut blendy_k2_prover, &mut ark_std::test_rng());
 
-        let mut time_prover = TimeProductProver::<F19, BenchStream<F19>>::new(<TimeProductProver<
-            F19,
-            BenchStream<F19>,
-        > as Prover<F19>>::ProverConfig::default(
+        let mut time_prover = TimeProductProver::<F64, BenchStream<F64>>::new(<TimeProductProver<
+            F64,
+            BenchStream<F64>,
+        > as Prover<F64>>::ProverConfig::default(
             claim,
             NUM_VARIABLES,
             evaluation_stream.clone(),
             evaluation_stream,
         ));
-        let time_prover_transcript = ProductSumcheck::<F19>::prove::<
-            BenchStream<F19>,
-            TimeProductProver<F19, BenchStream<F19>>,
+        let time_prover_transcript = ProductSumcheck::<F64>::prove::<
+            BenchStream<F64>,
+            TimeProductProver<F64, BenchStream<F64>>,
         >(&mut time_prover, &mut ark_std::test_rng());
         // ensure the transcript is identical
         assert_eq!(time_prover_transcript.is_accepted, true);

--- a/src/streams/memory/memory.rs
+++ b/src/streams/memory/memory.rs
@@ -24,9 +24,6 @@ impl<F: Field> MemoryStream<F> {
 }
 
 impl<F: Field> Stream<F> for MemoryStream<F> {
-    fn claim(&self) -> F {
-        self.evaluations.iter().sum()
-    }
     fn evaluation(&self, point: usize) -> F {
         self.evaluations[point]
     }

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -4,4 +4,4 @@ mod stream;
 
 pub use file::FileStream;
 pub use memory::MemoryStream;
-pub use stream::Stream;
+pub use stream::{multivariate_claim, multivariate_product_claim, Stream};

--- a/src/streams/stream.rs
+++ b/src/streams/stream.rs
@@ -1,7 +1,44 @@
 use ark_ff::Field;
 
+pub fn multivariate_claim<F: Field, S: Stream<F>>(stream: S) -> F {
+    let mut claim = F::zero();
+    let num_vars = stream.num_variables();
+    let num_evaluations = 2usize.pow(num_vars as u32);
+
+    for i in 0..num_evaluations {
+        let eval = stream.evaluation(i);
+        claim += eval * eval;
+    }
+
+    claim
+}
+
+pub fn multivariate_product_claim<F: Field, S: Stream<F>>(streams: Vec<S>) -> F {
+    // should be given at least one stream
+    let number_of_streams = streams.len();
+    assert!(number_of_streams > 0);
+
+    // all streams should have the same number of variables
+    let num_vars = streams[0].num_variables();
+    for stream in streams.iter() {
+        assert_eq!(stream.num_variables(), num_vars);
+    }
+
+    // calculate the claim
+    let mut claim = F::zero();
+    let num_evaluations = 2usize.pow(num_vars as u32);
+    for i in 0..num_evaluations {
+        let mut inner_sum = F::one();
+        for stream in streams.iter() {
+            inner_sum *= stream.evaluation(i);
+        }
+        claim += inner_sum;
+    }
+
+    claim
+}
+
 pub trait Stream<F: Field> {
-    fn claim(&self) -> F;
     fn evaluation(&self, point: usize) -> F;
     fn num_variables(&self) -> usize;
 }

--- a/src/tests/multilinear_product/provers/basic/prover.rs
+++ b/src/tests/multilinear_product/provers/basic/prover.rs
@@ -52,7 +52,7 @@ impl<F: Field> Prover<F> for BasicProductProver<F> {
 mod tests {
     use crate::{
         prover::Prover,
-        streams::{MemoryStream, Stream},
+        streams::{multivariate_product_claim, MemoryStream},
         tests::{
             multilinear_product::{
                 sanity_test_driver, BasicProductProver, BasicProductProverConfig,
@@ -63,8 +63,9 @@ mod tests {
     };
     #[test]
     fn sumcheck() {
+        let s = MemoryStream::<F19>::new(four_variable_polynomial_evaluations());
         sanity_test_driver(&mut BasicProductProver::new(BasicProductProverConfig::new(
-            MemoryStream::<F19>::new(four_variable_polynomial_evaluations()).claim(),
+            multivariate_product_claim(vec![s.clone(), s]),
             4,
             four_variable_polynomial(),
             four_variable_polynomial(),

--- a/src/tests/streams/bench/mod.rs
+++ b/src/tests/streams/bench/mod.rs
@@ -29,9 +29,6 @@ impl<F: Field> BenchStream<F> {
     }
 }
 impl<F: Field> Stream<F> for BenchStream<F> {
-    fn claim(&self) -> F {
-        self.claimed_sum
-    }
     fn evaluation(&self, point: usize) -> F {
         F::from(point as u64)
     }


### PR DESCRIPTION
What does this PR do?

- remove `claim()` function from stream trait as this doesn't make sense in the case of product sumcheck