### PR TITLE
Fix a test and some linter warnings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+rustflags = [
+  # cfg(feature = "asm") is an expected feature flag value
+  "--check-cfg=cfg(feature, values(\"asm\"))"
+]

--- a/src/multilinear_product/provers/blendy/blendy.rs
+++ b/src/multilinear_product/provers/blendy/blendy.rs
@@ -69,8 +69,6 @@ impl<F: Field, S: Stream<F>> BlendyProductProver<F, S> {
         }
         // if first few rounds, then no table is computed, need to compute sums from the streams
         else if self.current_round + 1 <= self.last_round_phase1 {
-            // let time1 = std::time::Instant::now();
-
             // Lag Poly
             let mut sequential_lag_poly: LagrangePolynomial<F, SignificantBitOrder> =
                 LagrangePolynomial::new(&self.verifier_messages_round_comp);
@@ -120,11 +118,9 @@ impl<F: Field, S: Stream<F>> BlendyProductProver<F, S> {
                 }
             }
             sum_half = sum_half * self.inverse_four;
-            // let time2 = std::time::Instant::now();
-            // println!("round computation from stream took: {:?}", time2 - time1);
-        }
-        // computing evaluations from the cross product tables
-        else {
+        } else {
+            // computing evaluations from the cross product tables
+
             // things to help iterating
             let b_prime_num_vars = self.current_round + 1 - self.prev_table_round_num;
             let v_num_vars: usize =
@@ -180,14 +176,8 @@ impl<F: Field, S: Stream<F>> BlendyProductProver<F, S> {
         let p = self.state_comp_set.contains(&j);
         let is_largest = self.state_comp_set.range((j + 1)..).next().is_none();
         if p && !is_largest {
-            // let time1 = std::time::Instant::now();
             let j_prime = self.prev_table_round_num;
             let t = self.prev_table_size;
-
-            // println!(
-            //     "table computation on round: {}, j_prime: {}, t: {}",
-            //     j, j_prime, t
-            // );
 
             // zero out the table
             let table_len = Hypercube::<SignificantBitOrder>::stop_value(t);
@@ -244,17 +234,10 @@ impl<F: Field, S: Stream<F>> BlendyProductProver<F, S> {
                     }
                 }
             }
-            // let time2 = std::time::Instant::now();
-            // println!("table computation took: {:?}", time2 - time1);
         } else if p && is_largest {
             // switch to the memory intensive sumcheck on the last round computation
             let num_variables_new = self.num_variables - j + 1;
             self.switched_to_vsbw = true;
-
-            // println!(
-            //     "switched to vsbw on round: {}, num_vars_new: {}",
-            //     j, num_variables_new
-            // );
 
             // reset the streams
             self.stream_iterators

--- a/src/multilinear_product/provers/blendy/prover.rs
+++ b/src/multilinear_product/provers/blendy/prover.rs
@@ -36,7 +36,6 @@ impl<F: Field, S: Stream<F>> Prover<F> for BlendyProductProver<F, S> {
                     std::cmp::min(current_round + max_rounds_phase2, current_round * 2 - 1); // the minus one is a time-efficiency optimization
                 current_round = std::cmp::max(current_round, 2);
             }
-            // println!("state_comp_set: {:?}", state_comp_set);
             state_comp_set
         };
         assert!(state_comp_set.len() > 0);
@@ -57,6 +56,7 @@ impl<F: Field, S: Stream<F>> Prover<F> for BlendyProductProver<F, S> {
             .cloned()
             .map(|s| StreamIterator::<F, S, SignificantBitOrder>::new(s))
             .collect();
+
         // return the BlendyProver instance
         Self {
             claim: prover_config.claim,
@@ -122,7 +122,7 @@ mod tests {
         prover::{ProductProverConfig, Prover},
         streams::{multivariate_product_claim, MemoryStream, Stream},
         tests::{
-            multilinear_product::{consistency_test, BasicProductProver, BasicProductProverConfig},
+            multilinear_product::{BasicProductProver, BasicProductProverConfig},
             polynomials::Polynomial,
             BenchStream, F64,
         },
@@ -158,7 +158,7 @@ mod tests {
             &mut Prover::<F64>::new(BlendyProductProverConfig::default(
                 claim,
                 num_variables,
-                vec![s.clone(), s],
+                vec![s.clone(), s.clone()],
             )),
             &mut ark_std::test_rng(),
         );
@@ -166,7 +166,7 @@ mod tests {
         // get transcript from SanityProver
         let p: SparsePolynomial<F64, SparseTerm> =
             <SparsePolynomial<F64, SparseTerm> as Polynomial<F64>>::from_hypercube_evaluations(
-                evals,
+                s.evaluations.clone(),
             );
         let mut sanity_prover = BasicProductProver::<F64>::new(BasicProductProverConfig::new(
             claim.clone(),


### PR DESCRIPTION
What does this PR do?

- reorders input for sanity product prover to make a test pass
- adds a cargo config file specifying that asm is an expected feature flag so that we stop getting warnings