### PR TITLE
Remove claim from Prover trait

### DIFF
--- a/benches/provers.rs
+++ b/benches/provers.rs
@@ -7,7 +7,6 @@ use efficient_sumcheck::{
     multilinear::TimeProver,
     multilinear_product::TimeProductProver,
     prover::{ProductProverConfig, Prover, ProverConfig},
-    streams::multivariate_product_claim,
     tests::{BenchStream, F128},
     ProductSumcheck, Sumcheck,
 };
@@ -29,9 +28,7 @@ fn time_prover_bench(c: &mut Criterion) {
                 let stream = BenchStream::<F128>::new(num_vars);
                 TimeProver::<F128, BenchStream<F128>>::new(
                     <TimeProver<F128, BenchStream<F128>> as Prover<F128>>::ProverConfig::default(
-                        stream.claimed_sum,
-                        num_vars,
-                        stream,
+                        num_vars, stream,
                     ),
                 )
             },
@@ -54,9 +51,7 @@ fn time_product_prover_bench(c: &mut Criterion) {
                 let stream = BenchStream::<F128>::new(num_vars);
                 let streams: Vec<BenchStream<F128>> = vec![stream.clone(), stream.clone()];
                 TimeProductProver::<F128, BenchStream<F128>>::new(ProductProverConfig::default(
-                    multivariate_product_claim(streams.clone()),
-                    num_vars,
-                    streams,
+                    num_vars, streams,
                 ))
             },
             |mut prover: TimeProductProver<F128, BenchStream<F128>>| {

--- a/benches/sumcheck-benches/Cargo.lock
+++ b/benches/sumcheck-benches/Cargo.lock
@@ -69,7 +69,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
- "rayon",
  "zeroize",
 ]
 
@@ -109,7 +108,6 @@ dependencies = [
  "educe",
  "fnv",
  "hashbrown",
- "rayon",
 ]
 
 [[package]]
@@ -123,7 +121,6 @@ dependencies = [
  "arrayvec",
  "digest",
  "num-bigint",
- "rayon",
 ]
 
 [[package]]
@@ -145,7 +142,6 @@ checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand",
- "rayon",
 ]
 
 [[package]]
@@ -165,31 +161,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -231,7 +202,6 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "memmap2",
- "rayon",
 ]
 
 [[package]]
@@ -401,26 +371,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "sumcheck-benches"

--- a/benches/sumcheck-benches/Cargo.toml
+++ b/benches/sumcheck-benches/Cargo.toml
@@ -9,7 +9,7 @@ ark-poly = "0.5.0"
 ark-serialize = "0.5.0"
 ark-std ="0.5.0"
 ark-bn254 = "0.5.0"
-efficient-sumcheck = { path = "../../." }
+efficient-sumcheck = { path = "../../.", default-features = false }
 
 [profile.release]
 debug = true

--- a/benches/sumcheck-benches/run_benches.sh
+++ b/benches/sumcheck-benches/run_benches.sh
@@ -2,7 +2,7 @@
 
 # We measure (i) wall time; and (ii) maximum resident set size, using the GNU-time facility.
 
-algorithms="Blendy2 VSBW Blendy1 Blendy3 Blendy4 CTY ProductBlendy2 ProductVSBW ProductCTY"
+algorithms="VSBW Blendy2 Blendy1 Blendy3 Blendy4 CTY ProductBlendy2 ProductVSBW ProductCTY"
 fields="Field64 Field128 FieldBn254"
 
 for algorithm in $algorithms; do

--- a/src/multilinear/mod.rs
+++ b/src/multilinear/mod.rs
@@ -4,6 +4,6 @@ mod sumcheck;
 pub use provers::{
     blendy::{BlendyProver, BlendyProverConfig},
     space::{SpaceProver, SpaceProverConfig},
-    time::{ReduceMode, TimeProver, TimeProverConfig},
+    time::{reductions, ReduceMode, TimeProver, TimeProverConfig},
 };
 pub use sumcheck::Sumcheck;

--- a/src/multilinear/provers/blendy/config.rs
+++ b/src/multilinear/provers/blendy/config.rs
@@ -1,4 +1,5 @@
 use ark_ff::Field;
+use ark_std::marker::PhantomData;
 
 use crate::{prover::ProverConfig, streams::Stream};
 
@@ -9,8 +10,8 @@ where
 {
     pub num_stages: usize,
     pub num_variables: usize,
-    pub claim: F,
     pub stream: S,
+    _f: PhantomData<F>,
 }
 
 impl<F, S> BlendyProverConfig<F, S>
@@ -18,23 +19,23 @@ where
     F: Field,
     S: Stream<F>,
 {
-    pub fn new(claim: F, num_stages: usize, num_variables: usize, stream: S) -> Self {
+    pub fn new(num_stages: usize, num_variables: usize, stream: S) -> Self {
         Self {
-            claim,
             num_stages,
             num_variables,
             stream,
+            _f: PhantomData::<F>,
         }
     }
 }
 
 impl<F: Field, S: Stream<F>> ProverConfig<F, S> for BlendyProverConfig<F, S> {
-    fn default(claim: F, num_variables: usize, stream: S) -> Self {
+    fn default(num_variables: usize, stream: S) -> Self {
         Self {
-            claim,
             num_stages: 2, // DEFAULT
             num_variables,
             stream,
+            _f: PhantomData::<F>,
         }
     }
 }

--- a/src/multilinear/provers/blendy/core.rs
+++ b/src/multilinear/provers/blendy/core.rs
@@ -16,7 +16,6 @@ where
     F: Field,
     S: Stream<F>,
 {
-    pub claimed_sum: F,
     pub current_round: usize,
     pub evaluation_stream: S,
     pub lag_polys: Vec<F>,

--- a/src/multilinear/provers/blendy/prover.rs
+++ b/src/multilinear/provers/blendy/prover.rs
@@ -21,7 +21,6 @@ where
     fn new(prover_config: Self::ProverConfig) -> Self {
         let stage_size: usize = prover_config.num_variables / prover_config.num_stages;
         Self {
-            claimed_sum: prover_config.claim,
             current_round: 0,
             evaluation_stream: prover_config.stream,
             num_stages: prover_config.num_stages,
@@ -61,10 +60,6 @@ where
 
         // Return the computed polynomial sums
         Some(sums)
-    }
-
-    fn claim(&self) -> F {
-        self.claimed_sum
     }
 }
 

--- a/src/multilinear/provers/space/config.rs
+++ b/src/multilinear/provers/space/config.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use ark_ff::Field;
 
 use crate::{
@@ -11,8 +13,8 @@ where
     S: Stream<F>,
 {
     pub num_variables: usize,
-    pub claim: F,
     pub streams: Vec<S>,
+    _f: PhantomData<F>,
 }
 
 impl<F, S> SpaceProverConfig<F, S>
@@ -20,31 +22,31 @@ where
     F: Field,
     S: Stream<F>,
 {
-    pub fn new(claim: F, num_variables: usize, stream: S) -> Self {
+    pub fn new(num_variables: usize, stream: S) -> Self {
         Self {
-            claim,
             num_variables,
             streams: vec![stream],
+            _f: PhantomData::<F>,
         }
     }
 }
 
 impl<F: Field, S: Stream<F>> ProverConfig<F, S> for SpaceProverConfig<F, S> {
-    fn default(claim: F, num_variables: usize, stream: S) -> Self {
+    fn default(num_variables: usize, stream: S) -> Self {
         Self {
-            claim,
             num_variables,
             streams: vec![stream],
+            _f: PhantomData::<F>,
         }
     }
 }
 
 impl<F: Field, S: Stream<F>> BatchProverConfig<F, S> for SpaceProverConfig<F, S> {
-    fn default(claim: F, num_variables: usize, streams: Vec<S>) -> Self {
+    fn default(num_variables: usize, streams: Vec<S>) -> Self {
         Self {
-            claim,
             num_variables,
             streams,
+            _f: PhantomData::<F>,
         }
     }
 }

--- a/src/multilinear/provers/space/core.rs
+++ b/src/multilinear/provers/space/core.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 
 pub struct SpaceProver<F: Field, S: Stream<F>> {
-    pub claim: F,
     pub current_round: usize,
     pub evaluation_streams: Vec<S>,
     pub num_variables: usize,

--- a/src/multilinear/provers/space/prover.rs
+++ b/src/multilinear/provers/space/prover.rs
@@ -11,13 +11,8 @@ impl<F: Field, S: Stream<F>> Prover<F> for SpaceProver<F, S> {
     type ProverMessage = Option<(F, F)>;
     type VerifierMessage = Option<F>;
 
-    fn claim(&self) -> F {
-        self.claim
-    }
-
     fn new(prover_config: Self::ProverConfig) -> Self {
         Self {
-            claim: prover_config.claim,
             evaluation_streams: prover_config.streams,
             verifier_messages: Vec::<F>::with_capacity(prover_config.num_variables),
             verifier_message_hats: Vec::<F>::with_capacity(prover_config.num_variables),

--- a/src/multilinear/provers/time/config.rs
+++ b/src/multilinear/provers/time/config.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use ark_ff::Field;
 
 use crate::{
@@ -12,9 +14,9 @@ where
     S: Stream<F>,
 {
     pub num_variables: usize,
-    pub claim: F,
     pub streams: Vec<S>,
     pub reduce_mode: ReduceMode,
+    _f: PhantomData<F>,
 }
 
 impl<F, S> TimeProverConfig<F, S>
@@ -22,34 +24,34 @@ where
     F: Field,
     S: Stream<F>,
 {
-    pub fn new(claim: F, num_variables: usize, stream: S, reduce_mode: ReduceMode) -> Self {
+    pub fn new(num_variables: usize, stream: S, reduce_mode: ReduceMode) -> Self {
         Self {
-            claim,
             num_variables,
             streams: vec![stream],
             reduce_mode,
+            _f: PhantomData::<F>,
         }
     }
 }
 
 impl<F: Field, S: Stream<F>> ProverConfig<F, S> for TimeProverConfig<F, S> {
-    fn default(claim: F, num_variables: usize, stream: S) -> Self {
+    fn default(num_variables: usize, stream: S) -> Self {
         Self {
-            claim,
             num_variables,
             streams: vec![stream],
             reduce_mode: ReduceMode::Pairwise,
+            _f: PhantomData::<F>,
         }
     }
 }
 
 impl<F: Field, S: Stream<F>> BatchProverConfig<F, S> for TimeProverConfig<F, S> {
-    fn default(claim: F, num_variables: usize, streams: Vec<S>) -> Self {
+    fn default(num_variables: usize, streams: Vec<S>) -> Self {
         Self {
-            claim,
             num_variables,
             streams,
             reduce_mode: ReduceMode::Pairwise,
+            _f: PhantomData::<F>,
         }
     }
 }

--- a/src/multilinear/provers/time/core.rs
+++ b/src/multilinear/provers/time/core.rs
@@ -5,7 +5,7 @@ use ark_std::vec::Vec;
 use crate::streams::Stream;
 
 pub struct TimeProver<F: Field, S: Stream<F>> {
-    pub claim: F,
+    // pub claim: F,
     pub current_round: usize,
     pub evaluations: Option<Vec<F>>,
     pub evaluation_streams: Vec<S>, // TODO (z-tech): this can be released after the first call to vsbw_reduce_evaluations

--- a/src/multilinear/provers/time/mod.rs
+++ b/src/multilinear/provers/time/mod.rs
@@ -1,7 +1,7 @@
 mod config;
 mod core;
 mod prover;
-mod reductions;
+pub mod reductions;
 
 pub use config::TimeProverConfig;
 pub use core::TimeProver;

--- a/src/multilinear/provers/time/prover.rs
+++ b/src/multilinear/provers/time/prover.rs
@@ -22,7 +22,6 @@ impl<F: Field, S: Stream<F>> TimeProver<F, S> {
                 pairwise::reduce_evaluations(
                     self.evaluations.as_mut().unwrap(),
                     verifier_message.unwrap(),
-                    F::ONE - verifier_message.unwrap(),
                 );
             } else {
                 self.evaluations = Some(vec![]);
@@ -30,7 +29,6 @@ impl<F: Field, S: Stream<F>> TimeProver<F, S> {
                     &self.evaluation_streams[0],
                     self.evaluations.as_mut().unwrap(),
                     verifier_message.unwrap(),
-                    F::ONE - verifier_message.unwrap(),
                 );
             }
         }
@@ -90,13 +88,9 @@ impl<F: Field, S: Stream<F>> Prover<F> for TimeProver<F, S> {
     type ProverMessage = Option<(F, F)>;
     type VerifierMessage = Option<F>;
 
-    fn claim(&self) -> F {
-        self.claim
-    }
-
     fn new(prover_config: Self::ProverConfig) -> Self {
         Self {
-            claim: prover_config.claim,
+            // claim: prover_config.claim,
             current_round: 0,
             evaluations: None,
             evaluation_streams: prover_config.streams,

--- a/src/multilinear/provers/time/reductions/mod.rs
+++ b/src/multilinear/provers/time/reductions/mod.rs
@@ -1,4 +1,5 @@
 pub mod pairwise;
+pub mod tablewise;
 pub mod variablewise;
 
 #[derive(Copy, Clone, Debug)]

--- a/src/multilinear/provers/time/reductions/pairwise.rs
+++ b/src/multilinear/provers/time/reductions/pairwise.rs
@@ -34,14 +34,10 @@ pub fn evaluate_from_stream<F: Field, S: Stream<F>>(src: &S) -> (F, F) {
     (even_sum, odd_sum)
 }
 
-pub fn reduce_evaluations<F: Field>(
-    src: &mut Vec<F>,
-    verifier_message: F,
-    verifier_message_hat: F,
-) {
+pub fn reduce_evaluations<F: Field>(src: &mut Vec<F>, verifier_message: F) {
     // compute from src
     let out: Vec<F> = cfg_chunks!(src, 2)
-        .map(|chunk| chunk[0] * verifier_message_hat + chunk[1] * verifier_message)
+        .map(|chunk| chunk[0] + verifier_message * (chunk[1] - chunk[0]))
         .collect();
     // write back into src
     src[..out.len()].copy_from_slice(&out);
@@ -52,7 +48,6 @@ pub fn reduce_evaluations_from_stream<F: Field, S: Stream<F>>(
     src: &S,
     dst: &mut Vec<F>,
     verifier_message: F,
-    verifier_message_hat: F,
 ) {
     // compute from stream
     let len = 1usize << src.num_variables();
@@ -60,7 +55,7 @@ pub fn reduce_evaluations_from_stream<F: Field, S: Stream<F>>(
         .map(|i| {
             let a = src.evaluation(2 * i);
             let b = src.evaluation((2 * i) + 1);
-            a * verifier_message_hat + b * verifier_message
+            a + verifier_message * (b - a)
         })
         .collect();
     *dst = out;

--- a/src/multilinear/provers/time/reductions/tablewise.rs
+++ b/src/multilinear/provers/time/reductions/tablewise.rs
@@ -1,0 +1,22 @@
+use ark_ff::Field;
+#[cfg(feature = "parallel")]
+use ark_std::{cfg_chunks, vec::Vec};
+#[cfg(feature = "parallel")]
+use rayon::{
+    iter::{IntoParallelIterator, ParallelIterator},
+    prelude::ParallelSlice,
+};
+
+pub fn reduce_evaluations<F: Field>(src: &mut Vec<Vec<F>>, verifier_message: F) {
+    let out: Vec<Vec<F>> = cfg_chunks!(src, 2)
+        .into_par_iter()
+        .map(|chunk| {
+            chunk[0]
+                .iter()
+                .zip(&chunk[1])
+                .map(|(&a, &b)| a + verifier_message * (b - a))
+                .collect::<Vec<F>>()
+        })
+        .collect();
+    *src = out;
+}

--- a/src/multilinear/provers/time/reductions/tablewise.rs
+++ b/src/multilinear/provers/time/reductions/tablewise.rs
@@ -1,15 +1,10 @@
 use ark_ff::Field;
-#[cfg(feature = "parallel")]
 use ark_std::{cfg_chunks, vec::Vec};
 #[cfg(feature = "parallel")]
-use rayon::{
-    iter::{IntoParallelIterator, ParallelIterator},
-    prelude::ParallelSlice,
-};
+use rayon::{iter::ParallelIterator, prelude::ParallelSlice};
 
 pub fn reduce_evaluations<F: Field>(src: &mut Vec<Vec<F>>, verifier_message: F) {
     let out: Vec<Vec<F>> = cfg_chunks!(src, 2)
-        .into_par_iter()
         .map(|chunk| {
             chunk[0]
                 .iter()

--- a/src/multilinear/provers/time/reductions/variablewise.rs
+++ b/src/multilinear/provers/time/reductions/variablewise.rs
@@ -1,25 +1,82 @@
 use ark_ff::Field;
+#[cfg(feature = "parallel")]
 use ark_std::cfg_into_iter;
 use ark_std::vec::Vec;
 #[cfg(feature = "parallel")]
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::iter::{
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator,
+};
 
 use crate::streams::Stream;
 
 pub fn evaluate<F: Field>(src: &[F]) -> (F, F) {
-    let sum_0 = cfg_into_iter!(0..src.len() / 2).map(|i| src[i]).sum();
-    let sum_1 = cfg_into_iter!(src.len() / 2..src.len())
-        .map(|i| src[i])
-        .sum();
+    let second_half_bit: usize = src.len() / 2;
+
+    #[cfg(feature = "parallel")]
+    let (sum_0, sum_1) = cfg_into_iter!(0..src.len())
+        .map(|i| {
+            let v = src[i];
+            if (i & second_half_bit) == 0 {
+                (v, F::zero())
+            } else {
+                (F::zero(), v)
+            }
+        })
+        .reduce(
+            || (F::zero(), F::zero()),
+            |(a0, a1), (b0, b1)| (a0 + b0, a1 + b1),
+        );
+
+    #[cfg(not(feature = "parallel"))]
+    let (sum_0, sum_1) = {
+        let mut sum_0 = F::ZERO;
+        let mut sum_1 = F::ZERO;
+        for i in 0..src.len() {
+            let v = src[i];
+            match i & second_half_bit != 0 {
+                false => sum_0 += v,
+                true => sum_1 += v,
+            }
+        }
+        (sum_0, sum_1)
+    };
+
     (sum_0, sum_1)
 }
 
 pub fn evaluate_from_stream<F: Field, S: Stream<F>>(src: &S) -> (F, F) {
     let len = 1usize << src.num_variables();
-    let sum_0 = cfg_into_iter!(0..len / 2).map(|i| src.evaluation(i)).sum();
-    let sum_1 = cfg_into_iter!(len / 2..len)
-        .map(|i| src.evaluation(i))
-        .sum();
+    let second_half_bit: usize = len / 2;
+
+    #[cfg(feature = "parallel")]
+    let (sum_0, sum_1) = cfg_into_iter!(0..len)
+        .map(|i| {
+            let v = src.evaluation(i);
+            if (i & second_half_bit) == 0 {
+                (v, F::zero())
+            } else {
+                (F::zero(), v)
+            }
+        })
+        .reduce(
+            || (F::zero(), F::zero()),
+            |(a0, a1), (b0, b1)| (a0 + b0, a1 + b1),
+        );
+
+    #[cfg(not(feature = "parallel"))]
+    let (sum_0, sum_1) = {
+        let mut sum_0 = F::ZERO;
+        let mut sum_1 = F::ZERO;
+        for i in 0..len {
+            let v = src.evaluation(i);
+            match i & second_half_bit != 0 {
+                false => sum_0 += v,
+                true => sum_1 += v,
+            }
+        }
+        (sum_0, sum_1)
+    };
+
     (sum_0, sum_1)
 }
 
@@ -29,14 +86,28 @@ pub fn reduce_evaluations<F: Field>(
     verifier_message_hat: F,
 ) {
     let second_half_bit: usize = src.len() / 2;
-    let out: Vec<F> = cfg_into_iter!(0..src.len() / 2)
-        .map(|i0| {
-            let v0 = src[i0];
-            let i1 = i0 | second_half_bit;
-            let v1 = src[i1];
-            v0 * verifier_message_hat + v1 * verifier_message
-        })
-        .collect();
+    let mut out = vec![F::ZERO; src.len() / 2];
+
+    #[cfg(feature = "parallel")]
+    {
+        out.par_iter_mut()
+            .enumerate()
+            .for_each(|(first_half_index, slot): (usize, &mut F)| {
+                let second_half_index = first_half_index | second_half_bit;
+                let v0 = src[first_half_index];
+                let v1 = src[second_half_index];
+                *slot = v0 * verifier_message_hat + v1 * verifier_message;
+            });
+    }
+
+    #[cfg(not(feature = "parallel"))]
+    for first_half_index in 0..src.len() / 2 {
+        let second_half_index = first_half_index | second_half_bit;
+        let v0 = src[first_half_index];
+        let v1 = src[second_half_index];
+        out[first_half_index] = v0 * verifier_message_hat + v1 * verifier_message;
+    }
+
     *src = out;
 }
 
@@ -48,13 +119,25 @@ pub fn reduce_evaluations_from_stream<F: Field, S: Stream<F>>(
 ) {
     let len = 1usize << src.num_variables();
     let second_half_bit: usize = len / 2;
-    let out: Vec<F> = cfg_into_iter!(0..len / 2)
-        .map(|i0| {
-            let v0 = src.evaluation(i0);
-            let i1 = i0 | second_half_bit;
-            let v1 = src.evaluation(i1);
-            v0 * verifier_message_hat + v1 * verifier_message
-        })
-        .collect();
+    let mut out = vec![F::ZERO; len / 2];
+
+    #[cfg(feature = "parallel")]
+    out.par_iter_mut()
+        .enumerate()
+        .for_each(|(first_half_index, slot): (usize, &mut F)| {
+            let second_half_index = first_half_index | second_half_bit;
+            let v0 = src.evaluation(first_half_index);
+            let v1 = src.evaluation(second_half_index);
+            *slot = v0 * verifier_message_hat + v1 * verifier_message;
+        });
+
+    #[cfg(not(feature = "parallel"))]
+    for first_half_index in 0..len / 2 {
+        let second_half_index = first_half_index | second_half_bit;
+        let v0 = src.evaluation(first_half_index);
+        let v1 = src.evaluation(second_half_index);
+        out[first_half_index] = v0 * verifier_message_hat + v1 * verifier_message;
+    }
+
     *dst = out;
 }

--- a/src/multilinear/sumcheck.rs
+++ b/src/multilinear/sumcheck.rs
@@ -27,7 +27,7 @@ impl<F: Field> Sumcheck<F> {
             let round_sum = message.0 + message.1;
             let is_round_accepted = match verifier_message {
                 // If first round, compare to claimed_sum
-                None => round_sum == prover.claim(),
+                None => true, // TODO (z-tech): we should give an option to supply claim round_sum == prover.claim(),
                 // Else compute f(prev_verifier_msg) = prev_sum_0 - (prev_sum_0 - prev_sum_1) * prev_verifier_msg == round_sum, store verifier message
                 Some(prev_verifier_message) => {
                     verifier_messages.push(prev_verifier_message);
@@ -83,7 +83,7 @@ mod tests {
 
         // 1) blendy
         let mut blendy_k3_prover = BlendyProver::<F19, BenchStream<F19>>::new(
-            BlendyProverConfig::new(claim, 3, NUM_VARIABLES, evaluation_stream.clone()),
+            BlendyProverConfig::new(3, NUM_VARIABLES, evaluation_stream.clone()),
         );
         let blendy_prover_transcript = Sumcheck::<F19>::prove::<
             BenchStream<F19>,
@@ -95,7 +95,6 @@ mod tests {
             F19,
             BenchStream<F19>,
         > as Prover<F19>>::ProverConfig::new(
-            claim,
             NUM_VARIABLES,
             evaluation_stream.clone(),
             ReduceMode::Variablewise,
@@ -135,7 +134,6 @@ mod tests {
             F19,
             BenchStream<F19>,
         > as Prover<F19>>::ProverConfig::default(
-            claim,
             NUM_VARIABLES,
             evaluation_stream,
         ));

--- a/src/multilinear_product/provers/blendy/config.rs
+++ b/src/multilinear_product/provers/blendy/config.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use ark_ff::Field;
 
 use crate::{prover::ProductProverConfig, streams::Stream};
@@ -11,8 +13,8 @@ where
 {
     pub num_stages: usize,
     pub num_variables: usize,
-    pub claim: F,
     pub streams: Vec<S>,
+    _f: PhantomData<F>,
 }
 
 impl<F, S> BlendyProductProverConfig<F, S>
@@ -20,23 +22,23 @@ where
     F: Field,
     S: Stream<F>,
 {
-    pub fn new(claim: F, num_stages: usize, num_variables: usize, streams: Vec<S>) -> Self {
+    pub fn new(num_stages: usize, num_variables: usize, streams: Vec<S>) -> Self {
         Self {
-            claim,
             num_stages,
             num_variables,
             streams,
+            _f: PhantomData::<F>,
         }
     }
 }
 
 impl<F: Field, S: Stream<F>> ProductProverConfig<F, S> for BlendyProductProverConfig<F, S> {
-    fn default(claim: F, num_variables: usize, streams: Vec<S>) -> Self {
+    fn default(num_variables: usize, streams: Vec<S>) -> Self {
         Self {
-            claim,
             num_stages: DEFAULT_NUM_STAGES,
             num_variables,
             streams,
+            _f: PhantomData::<F>,
         }
     }
 }

--- a/src/multilinear_product/provers/blendy/core.rs
+++ b/src/multilinear_product/provers/blendy/core.rs
@@ -11,7 +11,6 @@ use ark_std::vec::Vec;
 use std::collections::BTreeSet;
 
 pub struct BlendyProductProver<F: Field, S: Stream<F>> {
-    pub claim: F,
     pub current_round: usize,
     pub streams: Vec<S>,
     pub stream_iterators: Vec<StreamIterator<F, S, SignificantBitOrder>>,

--- a/src/multilinear_product/provers/blendy/prover.rs
+++ b/src/multilinear_product/provers/blendy/prover.rs
@@ -14,10 +14,6 @@ impl<F: Field, S: Stream<F>> Prover<F> for BlendyProductProver<F, S> {
     type ProverMessage = Option<(F, F, F)>;
     type VerifierMessage = Option<F>;
 
-    fn claim(&self) -> F {
-        self.claim
-    }
-
     fn new(prover_config: Self::ProverConfig) -> Self {
         let num_variables: usize = prover_config.num_variables;
         let num_stages: usize = prover_config.num_stages;
@@ -42,7 +38,6 @@ impl<F: Field, S: Stream<F>> Prover<F> for BlendyProductProver<F, S> {
 
         let last_round: usize = *state_comp_set.iter().max().unwrap();
         let vsbw_prover = TimeProductProver::<F, S> {
-            claim: prover_config.claim,
             current_round: 0,
             evaluations: vec![None; 2],
             streams: None,
@@ -59,7 +54,6 @@ impl<F: Field, S: Stream<F>> Prover<F> for BlendyProductProver<F, S> {
 
         // return the BlendyProver instance
         Self {
-            claim: prover_config.claim,
             current_round: 0,
             streams: prover_config.streams,
             stream_iterators,
@@ -155,7 +149,6 @@ mod tests {
             BlendyProductProver<F64, MemoryStream<F64>>,
         >(
             &mut Prover::<F64>::new(BlendyProductProverConfig::default(
-                claim,
                 num_variables,
                 vec![s.clone(), s.clone()],
             )),

--- a/src/multilinear_product/provers/space/config.rs
+++ b/src/multilinear_product/provers/space/config.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use ark_ff::Field;
 
 use crate::{prover::ProductProverConfig, streams::Stream};
@@ -8,8 +10,8 @@ where
     S: Stream<F>,
 {
     pub num_variables: usize,
-    pub claim: F,
     pub streams: Vec<S>,
+    _f: PhantomData<F>,
 }
 
 impl<F, S> SpaceProductProverConfig<F, S>
@@ -17,21 +19,21 @@ where
     F: Field,
     S: Stream<F>,
 {
-    pub fn new(claim: F, num_variables: usize, streams: Vec<S>) -> Self {
+    pub fn new(num_variables: usize, streams: Vec<S>) -> Self {
         Self {
-            claim,
             num_variables,
             streams,
+            _f: PhantomData::<F>,
         }
     }
 }
 
 impl<F: Field, S: Stream<F>> ProductProverConfig<F, S> for SpaceProductProverConfig<F, S> {
-    fn default(claim: F, num_variables: usize, streams: Vec<S>) -> Self {
+    fn default(num_variables: usize, streams: Vec<S>) -> Self {
         Self {
-            claim,
             num_variables,
             streams,
+            _f: PhantomData::<F>,
         }
     }
 }

--- a/src/multilinear_product/provers/space/core.rs
+++ b/src/multilinear_product/provers/space/core.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 
 pub struct SpaceProductProver<F: Field, S: Stream<F>> {
-    pub claim: F,
     pub current_round: usize,
     pub stream_iterators: Vec<StreamIterator<F, S, SignificantBitOrder>>,
     pub num_variables: usize,

--- a/src/multilinear_product/provers/space/prover.rs
+++ b/src/multilinear_product/provers/space/prover.rs
@@ -13,10 +13,6 @@ impl<F: Field, S: Stream<F>> Prover<F> for SpaceProductProver<F, S> {
     type ProverMessage = Option<(F, F, F)>;
     type VerifierMessage = Option<F>;
 
-    fn claim(&self) -> F {
-        self.claim
-    }
-
     fn new(prover_config: Self::ProverConfig) -> Self {
         let stream_iterators = prover_config
             .streams
@@ -26,7 +22,6 @@ impl<F: Field, S: Stream<F>> Prover<F> for SpaceProductProver<F, S> {
             .collect();
 
         Self {
-            claim: prover_config.claim,
             stream_iterators,
             verifier_messages: VerifierMessages::new(&vec![]),
             current_round: 0,

--- a/src/multilinear_product/provers/time/config.rs
+++ b/src/multilinear_product/provers/time/config.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use ark_ff::Field;
 
 use crate::{prover::ProductProverConfig, streams::Stream};
@@ -8,8 +10,8 @@ where
     S: Stream<F>,
 {
     pub num_variables: usize,
-    pub claim: F,
     pub streams: Vec<S>,
+    _f: PhantomData<F>,
 }
 
 impl<F, S> TimeProductProverConfig<F, S>
@@ -17,21 +19,21 @@ where
     F: Field,
     S: Stream<F>,
 {
-    pub fn new(claim: F, num_variables: usize, streams: Vec<S>) -> Self {
+    pub fn new(num_variables: usize, streams: Vec<S>) -> Self {
         Self {
-            claim,
             num_variables,
             streams,
+            _f: PhantomData::<F>,
         }
     }
 }
 
 impl<F: Field, S: Stream<F>> ProductProverConfig<F, S> for TimeProductProverConfig<F, S> {
-    fn default(claim: F, num_variables: usize, streams: Vec<S>) -> Self {
+    fn default(num_variables: usize, streams: Vec<S>) -> Self {
         Self {
-            claim,
             num_variables,
             streams,
+            _f: PhantomData::<F>,
         }
     }
 }

--- a/src/multilinear_product/provers/time/core.rs
+++ b/src/multilinear_product/provers/time/core.rs
@@ -8,7 +8,6 @@ use rayon::iter::{
 use crate::streams::Stream;
 
 pub struct TimeProductProver<F: Field, S: Stream<F>> {
-    pub claim: F,
     pub current_round: usize,
     pub evaluations: Vec<Option<Vec<F>>>,
     pub streams: Option<Vec<S>>,

--- a/src/multilinear_product/provers/time/prover.rs
+++ b/src/multilinear_product/provers/time/prover.rs
@@ -11,14 +11,9 @@ impl<F: Field, S: Stream<F>> Prover<F> for TimeProductProver<F, S> {
     type ProverMessage = Option<(F, F, F)>;
     type VerifierMessage = Option<F>;
 
-    fn claim(&self) -> F {
-        self.claim
-    }
-
     fn new(prover_config: Self::ProverConfig) -> Self {
         let num_variables = prover_config.num_variables;
         Self {
-            claim: prover_config.claim,
             current_round: 0,
             evaluations: vec![None; prover_config.streams.len()],
             streams: Some(prover_config.streams),

--- a/src/multilinear_product/sumcheck.rs
+++ b/src/multilinear_product/sumcheck.rs
@@ -30,7 +30,7 @@ impl<F: Field> ProductSumcheck<F> {
             let round_sum = message.0 + message.1;
             let is_round_accepted = match verifier_message {
                 // If first round, compare to claimed_sum
-                None => round_sum == prover.claim(),
+                None => true, // TODO (z-tech): give option to provide claim round_sum == prover.claim(),
                 Some(prev_verifier_message) => {
                     verifier_messages.push(prev_verifier_message);
                     let prev_prover_message = prover_messages.last().unwrap();

--- a/src/prover/core.rs
+++ b/src/prover/core.rs
@@ -2,22 +2,21 @@ use ark_ff::Field;
 
 use crate::streams::Stream;
 pub trait ProverConfig<F: Field, S: Stream<F>> {
-    fn default(claim: F, num_variables: usize, stream: S) -> Self;
+    fn default(num_variables: usize, stream: S) -> Self;
 }
 
 pub trait BatchProverConfig<F: Field, S: Stream<F>> {
-    fn default(claim: F, num_variables: usize, streams: Vec<S>) -> Self;
+    fn default(num_variables: usize, streams: Vec<S>) -> Self;
 }
 
 pub trait ProductProverConfig<F: Field, S: Stream<F>> {
-    fn default(claim: F, num_variables: usize, steams: Vec<S>) -> Self;
+    fn default(num_variables: usize, steams: Vec<S>) -> Self;
 }
 
 pub trait Prover<F: Field> {
     type ProverConfig;
     type ProverMessage;
     type VerifierMessage;
-    fn claim(&self) -> F;
     fn new(prover_config: Self::ProverConfig) -> Self;
     fn next_message(&mut self, verifier_message: Self::VerifierMessage) -> Self::ProverMessage;
 }

--- a/src/tests/fields.rs
+++ b/src/tests/fields.rs
@@ -1,9 +1,5 @@
-// use ark_ff::SqrtPrecomputation;
-use ark_ff::{
-    // ark_ff_macros::SmallFpConfig,
-    fields::{Fp128, Fp64, MontBackend, MontConfig},
-    // BigInt, SmallFp, SmallFpConfig,
-};
+use ark_ff::fields::{Fp128, Fp64, MontBackend, MontConfig};
+
 #[derive(MontConfig)]
 #[modulus = "19"]
 #[generator = "2"]
@@ -17,6 +13,12 @@ pub struct M31Config;
 pub type M31 = Fp64<MontBackend<M31Config, 1>>;
 
 #[derive(MontConfig)]
+#[modulus = "2013265921"] // BabyBear 2^{31} - 2^{27} + 1
+#[generator = "2"]
+pub struct BabyBearConfig;
+pub type BabyBear = Fp64<MontBackend<BabyBearConfig, 1>>;
+
+#[derive(MontConfig)]
 #[modulus = "18446744069414584321"] // q = 2^64 - 2^32 + 1
 #[generator = "2"]
 pub struct F64Config;
@@ -27,17 +29,3 @@ pub type F64 = Fp64<MontBackend<F64Config, 1>>;
 #[generator = "2"]
 pub struct F128Config;
 pub type F128 = Fp128<MontBackend<F128Config, 2>>;
-
-// #[derive(SmallFpConfig)]
-// #[modulus = "2147483647"] // 2 ^ 31 - 1
-// #[generator = "2"]
-// #[backend = "montgomery"]
-// pub struct SmallM31ConfigMont;
-// pub type SmallM31 = SmallFp<SmallM31ConfigMont>;
-
-// #[derive(SmallFpConfig)]
-// #[modulus = "18446744069414584321"] // Goldilock's prime 2^64 - 2^32 + 1
-// #[generator = "2"]
-// #[backend = "montgomery"]
-// pub struct SmallF64ConfigMont;
-// pub type SmallGoldilocks = SmallFp<SmallF64ConfigMont>;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -4,5 +4,5 @@ mod streams;
 pub mod multilinear;
 pub mod multilinear_product;
 pub mod polynomials;
-pub use fields::{F128, F19, F64, M31}; // SmallGoldilocks, SmallM31,
+pub use fields::{BabyBear, F128, F19, F64, M31};
 pub use streams::BenchStream;

--- a/src/tests/multilinear/provers/basic/core.rs
+++ b/src/tests/multilinear/provers/basic/core.rs
@@ -6,7 +6,6 @@ use crate::{
     tests::polynomials::Polynomial,
 };
 pub struct BasicProver<F: Field> {
-    pub claim: F,
     pub current_round: usize,
     pub num_variables: usize,
     pub p: SparsePolynomial<F, SparseTerm>,

--- a/src/tests/multilinear/provers/basic/prover.rs
+++ b/src/tests/multilinear/provers/basic/prover.rs
@@ -11,13 +11,8 @@ impl<F: Field> Prover<F> for BasicProver<F> {
     type ProverMessage = Option<(F, F)>;
     type VerifierMessage = Option<F>;
 
-    fn claim(&self) -> F {
-        self.claim
-    }
-
     fn new(prover_config: Self::ProverConfig) -> Self {
         Self {
-            claim: prover_config.claim,
             current_round: 0,
             num_variables: prover_config.num_variables,
             p: prover_config.p,

--- a/src/tests/multilinear/sanity.rs
+++ b/src/tests/multilinear/sanity.rs
@@ -24,7 +24,7 @@ where
     P::ProverConfig: ProverConfig<F, S>,
 {
     let s: S = MemoryStream::new(three_variable_polynomial_evaluations()).into();
-    let mut p = P::new(ProverConfig::default(F::from(6_u32), 3, s));
+    let mut p = P::new(ProverConfig::default(3, s));
     /*
      * Zeroth Round: All variables are free
      *
@@ -92,7 +92,7 @@ where
     P::ProverConfig: ProverConfig<F, S>,
 {
     let s: S = MemoryStream::new(three_variable_polynomial_evaluations()).into();
-    let mut p = P::new(ProverConfig::default(F::from(6_u32), 3, s));
+    let mut p = P::new(ProverConfig::default(3, s));
     /*
      * Zeroth Round: All variables are free
      *

--- a/src/tests/multilinear_product/consistency.rs
+++ b/src/tests/multilinear_product/consistency.rs
@@ -40,7 +40,6 @@ where
     // prove
     let prover_transcript = ProductSumcheck::<F>::prove::<BenchStream<F>, P>(
         &mut P::new(ProductProverConfig::default(
-            claim,
             num_variables,
             vec![s.clone(), s],
         )),

--- a/src/tests/multilinear_product/provers/basic/core.rs
+++ b/src/tests/multilinear_product/provers/basic/core.rs
@@ -6,7 +6,6 @@ use crate::{
     tests::polynomials::Polynomial,
 };
 pub struct BasicProductProver<F: Field> {
-    pub claim: F,
     pub current_round: usize,
     pub inverse_four: F,
     pub num_variables: usize,

--- a/src/tests/multilinear_product/provers/basic/prover.rs
+++ b/src/tests/multilinear_product/provers/basic/prover.rs
@@ -11,13 +11,8 @@ impl<F: Field> Prover<F> for BasicProductProver<F> {
     type ProverMessage = Option<(F, F, F)>;
     type VerifierMessage = Option<F>;
 
-    fn claim(&self) -> F {
-        self.claim
-    }
-
     fn new(prover_config: Self::ProverConfig) -> Self {
         Self {
-            claim: prover_config.claim,
             current_round: 0,
             inverse_four: F::from(4_u32).inverse().unwrap(),
             num_variables: prover_config.num_variables,

--- a/src/tests/multilinear_product/sanity.rs
+++ b/src/tests/multilinear_product/sanity.rs
@@ -140,10 +140,6 @@ where
 {
     let s_p: S = MemoryStream::new(four_variable_polynomial_evaluations()).into();
     let s_q: S = MemoryStream::new(four_variable_polynomial_evaluations()).into();
-    let mut p = P::new(ProductProverConfig::default(
-        F::from(18_u32),
-        4,
-        vec![s_p, s_q],
-    ));
+    let mut p = P::new(ProductProverConfig::default(4, vec![s_p, s_q]));
     sanity_test_driver(&mut p);
 }


### PR DESCRIPTION
What does this PR do?

- removes global claim related functions and fields that make it tricky to initialize a prover when the claim hasn't already been calculated