### PR TITLE
Allow to owned on coeff sumcheck prover

### DIFF
--- a/src/provers/coefficient.rs
+++ b/src/provers/coefficient.rs
@@ -47,6 +47,21 @@ impl<'a, F: Field, E: RoundPolyEvaluator<F>> CoefficientProver<'a, F, E> {
         &self.pairwise
     }
 
+    /// Consume the prover and return the (tablewise, pairwise) tables by move.
+    ///
+    /// Intended for end-of-sumcheck extraction: callers that have completed
+    /// all rounds and want to forward the reduced state to a downstream
+    /// protocol (witness, transcript, accumulator) without cloning. Returning
+    /// both buffers in one call avoids the partial-move trap that single-field
+    /// `self`-consuming accessors would create.
+    ///
+    /// If called before sumcheck has run to completion the buffers reflect
+    /// the current partial-fold state — meaningful only if the caller is
+    /// tracking rounds explicitly.
+    pub fn finalize(self) -> (Vec<Vec<Vec<F>>>, Vec<Vec<F>>) {
+        (self.tablewise, self.pairwise)
+    }
+
     fn half(&self) -> usize {
         if self.n_tw > 0 {
             self.tablewise[0].len() / 2

--- a/src/provers/coefficient_lsb.rs
+++ b/src/provers/coefficient_lsb.rs
@@ -75,6 +75,21 @@ impl<'a, F: Field, E: RoundPolyEvaluator<F>> CoefficientProverLSB<'a, F, E> {
         &self.pairwise
     }
 
+    /// Consume the prover and return the (tablewise, pairwise) tables by move.
+    ///
+    /// Intended for end-of-sumcheck extraction: callers that have completed
+    /// all rounds and want to forward the reduced state to a downstream
+    /// protocol (witness, transcript, accumulator) without cloning. Returning
+    /// both buffers in one call avoids the partial-move trap that single-field
+    /// `self`-consuming accessors would create.
+    ///
+    /// If called before sumcheck has run to completion the buffers reflect
+    /// the current partial-fold state — meaningful only if the caller is
+    /// tracking rounds explicitly.
+    pub fn finalize(self) -> (Vec<Vec<Vec<F>>>, Vec<Vec<F>>) {
+        (self.tablewise, self.pairwise)
+    }
+
     fn n_pairs(&self) -> usize {
         if self.n_tw > 0 {
             self.tablewise[0].len() / 2


### PR DESCRIPTION
## Summary

Add `finalize(self) -> (Vec<Vec<Vec<F>>>, Vec<Vec<F>>)` to `CoefficientProver` and `CoefficientProverLSB`, alongside the existing borrow accessors. Lets downstream callers extract the post-sumcheck reduced state by move instead of cloning out of a borrow.

## Before

`CoefficientProver{,LSB}` own their working buffers (`tablewise: Vec<Vec<Vec<F>>>`, `pairwise: Vec<Vec<F>>`) but expose them only behind `&self` accessors. Callers that have finished sumcheck and need the folded state — to feed a witness, embed in a transcript, hand to a downstream protocol — cannot take it. They must clone:

```rust
let reduced_tw = sc.tablewise();           // &[Vec<Vec<F>>] — borrow
let witness_a = reduced_tw[0][0].clone();  // clone, because we only have &
let witness_b = reduced_tw[1][0].clone();  // clone
// sc still alive, never used again
```

Each `.clone()` is a heap allocation plus k field-element copies (k = constraint arity). The pattern itself is a Rust API smell: a borrow returned solely so the caller can immediately clone it back to owned. The library knows the prover won't be used again. The caller knows. The type system can't express "transfer ownership of the post-fold buffers."

This isn't unique to one downstream — anyone composing `CoefficientProverLSB` into a larger proof system hits the identical shape (run sumcheck, extract reduced state, feed next phase, drop prover).

## After

```rust
pub fn finalize(self) -> (Vec<Vec<Vec<F>>>, Vec<Vec<F>>) {
    (self.tablewise, self.pairwise)
}
```

Canonical Rust pattern: `foo(&self) -> &T` for inspection, consume-and-return for extraction. Single method returning both buffers in a tuple, so callers can't accidentally try to move out the same prover twice:

```rust
let (reduced_tw, _) = sc.finalize();   // by move, no clone, sc consumed
```

The `&self` accessors stay — they remain correct for inspection / asserts / debugging mid-sumcheck. Existing call sites compile unchanged.
