### PR TITLE
Make so EffSc can be consumed without Spongefish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ark-serialize = { version = "0.6.0", optional = true }
 ark-std = { version = "0.6.0", optional = true }
 memmap2 = "0.9.5"
 nohash-hasher = "0.2.0"
+rand_core = { version = "0.6", default-features = false }
 rayon = { version = "1.10", optional = true }
 spongefish = { version = "0.7.0", features = ["ark-ff"], optional = true }
 zerocopy = { version = "0.8", features = ["derive"] }
@@ -30,14 +31,14 @@ p3-field = "0.5"
 p3-goldilocks = "0.5"
 
 [features]
-default = ["arkworks", "parallel", "simd"]
+default = ["arkworks", "spongefish", "parallel", "simd"]
 arkworks = [
   "dep:ark-ff",
   "dep:ark-poly",
   "dep:ark-serialize",
   "dep:ark-std",
-  "dep:spongefish",
 ]
+spongefish = ["dep:spongefish", "arkworks"]
 simd = []
 parallel = [
   "dep:rayon",

--- a/src/coefficient_sumcheck.rs
+++ b/src/coefficient_sumcheck.rs
@@ -464,8 +464,6 @@ mod tests {
 
     #[test]
     fn test_spongefish_transcript() {
-        use crate::transcript::SpongefishTranscript;
-
         let mut rng = test_rng();
         let n = 1 << 3;
         let num_rounds = 3;
@@ -475,8 +473,7 @@ mod tests {
             .without_session()
             .instance(b"test");
 
-        let prover_state = domsep.std_prover();
-        let mut transcript = SpongefishTranscript::new(prover_state);
+        let mut prover_state = domsep.std_prover();
 
         let mut pairwise = vec![evals];
         let mut tablewise: Vec<Vec<Vec<F64>>> = vec![];
@@ -486,7 +483,7 @@ mod tests {
             &mut tablewise,
             &mut pairwise,
             num_rounds,
-            &mut transcript,
+            &mut prover_state,
         );
 
         assert_eq!(result.prover_messages.len(), num_rounds);

--- a/src/transcript/mod.rs
+++ b/src/transcript/mod.rs
@@ -1,12 +1,8 @@
-#[cfg(feature = "arkworks")]
 mod sanity;
-#[cfg(feature = "arkworks")]
+#[cfg(feature = "spongefish")]
 mod spongefish;
 #[allow(clippy::module_inception)]
 mod transcript;
 
-#[cfg(feature = "arkworks")]
 pub use sanity::{SanityTranscript, TestTranscript};
-#[cfg(feature = "arkworks")]
-pub use spongefish::SpongefishTranscript;
 pub use transcript::{ProverTranscript, VerifierTranscript};

--- a/src/transcript/sanity.rs
+++ b/src/transcript/sanity.rs
@@ -1,6 +1,6 @@
-use ark_ff::Field;
-use ark_std::rand::Rng;
+use rand_core::RngCore;
 
+use crate::field::SumcheckField;
 use crate::transcript::{ProverTranscript, VerifierTranscript};
 
 /// Test transcript: sends are no-ops, receives return `Ok(random)`,
@@ -19,33 +19,36 @@ impl<'a, R> TestTranscript<'a, R> {
     }
 }
 
+// Randomness is `from_u64(rng.next_u64())` — base-field-width lifted into
+// extensions. Adequate for a test transcript whose only soundness need is
+// avoiding accidental collisions.
 impl<'a, F, R> ProverTranscript<F> for TestTranscript<'a, R>
 where
-    F: Field,
-    R: Rng,
+    F: SumcheckField,
+    R: RngCore,
 {
     fn send(&mut self, _value: F) {
         // no-op
     }
 
     fn challenge(&mut self) -> F {
-        F::rand(&mut self.rng)
+        F::from_u64(self.rng.next_u64())
     }
 }
 
 impl<'a, F, R> VerifierTranscript<F> for TestTranscript<'a, R>
 where
-    F: Field,
-    R: Rng,
+    F: SumcheckField,
+    R: RngCore,
 {
     type Error = core::convert::Infallible;
 
     fn receive(&mut self) -> Result<F, Self::Error> {
-        Ok(F::rand(&mut self.rng))
+        Ok(F::from_u64(self.rng.next_u64()))
     }
 
     fn challenge(&mut self) -> F {
-        F::rand(&mut self.rng)
+        F::from_u64(self.rng.next_u64())
     }
 }
 

--- a/src/transcript/spongefish.rs
+++ b/src/transcript/spongefish.rs
@@ -1,61 +1,44 @@
+//! Bridge impls between effsc's transcript traits and spongefish.
+//!
+//! Lives here (rather than in a separate `effsc-spongefish` crate) because
+//! the orphan rule forces the impl into a crate that owns one of the two
+//! traits, and a separate crate would only add Cargo overhead. Disable the
+//! `spongefish` feature to compile effsc without this module.
+
 use ark_ff::Field;
 use ark_std::rand::{CryptoRng, RngCore};
-use spongefish::{Decoding, Encoding, ProverState, StdHash};
+use spongefish::{
+    Decoding, DuplexSpongeInterface, Encoding, NargDeserialize, NargSerialize, ProverState,
+    VerifierState,
+};
 
-use crate::transcript::ProverTranscript;
+use crate::transcript::{ProverTranscript, VerifierTranscript};
 
-/// Spongefish prover transcript.
-///
-/// Implements [`ProverTranscript`] only — the verifier side should wrap
-/// spongefish's `VerifierState` and implement [`VerifierTranscript`](super::VerifierTranscript).
-pub struct SpongefishTranscript<R: RngCore + CryptoRng = ark_std::rand::rngs::StdRng>(
-    pub ProverState<StdHash, R>,
-);
-
-impl<F, R> ProverTranscript<F> for SpongefishTranscript<R>
+impl<F, H, R> ProverTranscript<F> for ProverState<H, R>
 where
-    F: Field + Encoding<[u8]> + Decoding<[u8]>,
-    R: RngCore + CryptoRng,
-{
-    fn send(&mut self, value: F) {
-        self.0.prover_message(&value);
-    }
-
-    fn challenge(&mut self) -> F {
-        self.0.verifier_message::<F>()
-    }
-}
-
-/// Blanket impl so raw `ProverState` can be used as a `ProverTranscript` directly.
-impl<F, H, R> ProverTranscript<F> for spongefish::ProverState<H, R>
-where
-    F: Field + Encoding<[H::U]> + Decoding<[H::U]> + spongefish::NargSerialize,
-    H: spongefish::DuplexSpongeInterface,
+    F: Field + Encoding<[H::U]> + Decoding<[H::U]> + NargSerialize,
+    H: DuplexSpongeInterface,
     R: RngCore + CryptoRng,
 {
     fn send(&mut self, value: F) {
         self.prover_message(&value);
     }
-
     fn challenge(&mut self) -> F {
         self.verifier_message::<F>()
     }
 }
 
-impl<R> SpongefishTranscript<R>
+impl<'a, F, H> VerifierTranscript<F> for VerifierState<'a, H>
 where
-    R: RngCore + CryptoRng,
+    F: Field + Encoding<[H::U]> + Decoding<[H::U]> + NargDeserialize,
+    H: DuplexSpongeInterface,
 {
-    pub fn new(prover_state: ProverState<StdHash, R>) -> Self {
-        Self(prover_state)
+    type Error = spongefish::VerificationError;
+
+    fn receive(&mut self) -> Result<F, Self::Error> {
+        self.prover_message::<F>()
     }
-    pub fn into_inner(self) -> ProverState<StdHash, R> {
-        self.0
-    }
-    pub fn as_inner(&self) -> &ProverState<StdHash, R> {
-        &self.0
-    }
-    pub fn as_inner_mut(&mut self) -> &mut ProverState<StdHash, R> {
-        &mut self.0
+    fn challenge(&mut self) -> F {
+        self.verifier_message::<F>()
     }
 }


### PR DESCRIPTION
## Summary

Splits the `spongefish` Cargo feature out of `arkworks` so downstream crates can consume effsc with arkworks fields but no Fiat-Shamir backend. Adds the missing `VerifierTranscript` blanket on `spongefish::VerifierState` (symmetric to the existing `ProverTranscript` blanket) so consumers no longer need a hand-written verifier adapter. Drops the now-redundant `SpongefishTranscript` wrapper struct.

## Breaking change

`effsc::transcript::SpongefishTranscript` is removed — replace `SpongefishTranscript::new(state)` with the raw `state` (the blanket impl makes `&mut ProverState<H, R>` directly usable wherever `&mut impl ProverTranscript<F>` is expected).

## Changes

- **`Cargo.toml`** — `spongefish` is now its own feature (implies `arkworks`); `arkworks` no longer pulls spongefish. Promotes `rand_core` from a transitive to a direct dep so `sanity.rs` can name `RngCore` without going through `ark-std`.
- **`src/transcript/mod.rs`** — ungates `sanity`; gates `spongefish` module on the new feature; drops the `SpongefishTranscript` re-export.
- **`src/transcript/sanity.rs`** — `F: ark_ff::Field` → `F: SumcheckField`, `R: Rng` → `R: RngCore`, `F::rand(rng)` → `F::from_u64(rng.next_u64())`. Now compiles under `--no-default-features`.
- **`src/transcript/spongefish.rs`** — deletes the wrapper struct and its inherent methods; adds the `VerifierTranscript` blanket on `VerifierState<'a, H>`.
- **`src/coefficient_sumcheck.rs`** — test passes raw `&mut prover_state` instead of wrapping it.

## Test plan

- [x] `cargo build --no-default-features --features=arkworks` succeeds; `cargo tree` confirms no spongefish in the dep graph
- [x] `cargo build --no-default-features` succeeds
- [x] `cargo build` (default features) succeeds
- [x] `cargo test --all-features` — 128 tests pass
- [x] `cargo clippy --all-features --lib` clean (pre-existing lints in test files unchanged)