### PR TITLE
Perf/inner product fused kernel

### DIFF
--- a/src/inner_product_sumcheck.rs
+++ b/src/inner_product_sumcheck.rs
@@ -172,7 +172,8 @@ pub fn fold<F: SumcheckField>(values: &mut Vec<F>, weight: F) {
     scalar_mul(tail, F::ONE - weight);
 
     values.truncate(half);
-    values.shrink_to_fit();
+    // Skip shrink_to_fit — realloc per round is pricier than the capacity
+    // we carry; the capacity frees once the Vec drops.
 }
 
 /// Two-pass fold-then-compute; reference version kept for testing.

--- a/src/multilinear_sumcheck.rs
+++ b/src/multilinear_sumcheck.rs
@@ -140,7 +140,6 @@ pub fn fold<F: SumcheckField>(values: &mut Vec<F>, weight: F) {
     ))]
     {
         if crate::simd_sumcheck::dispatch::try_simd_reduce_msb(values, weight) {
-            values.shrink_to_fit();
             return;
         }
     }
@@ -174,7 +173,8 @@ pub fn fold<F: SumcheckField>(values: &mut Vec<F>, weight: F) {
     scalar_mul(tail, F::ONE - weight);
 
     values.truncate(half);
-    values.shrink_to_fit();
+    // Skip shrink_to_fit — realloc per round is pricier than the capacity
+    // we carry; the capacity frees once the Vec drops.
 }
 
 /// Two-pass fold-then-compute. Reference only.

--- a/src/provers/inner_product.rs
+++ b/src/provers/inner_product.rs
@@ -59,56 +59,15 @@ where
     }
 
     fn round(&mut self, challenge: Option<F>) -> Vec<F> {
-        // Fold with previous challenge (if any).
-        if let Some(w) = challenge {
-            ip::fold(&mut self.a, w);
-            ip::fold(&mut self.b, w);
-        }
-
         // EvalsInfty: emit [q(0), q(∞)] where
         //   q(0)  = dot(a_lo, b_lo)
         //   q(∞)  = [x²] q(x) = dot(a_hi − a_lo, b_hi − b_lo)
-        //         = Σ (ah − al)·(bh − bl)
         // The verifier derives q(1) = claim - q(0).
-        let n = self.a.len();
-        if n <= 1 {
-            let v = if n == 1 {
-                self.a[0] * self.b[0]
-            } else {
-                F::ZERO
-            };
-            return vec![v, F::ZERO];
-        }
-
-        let half = n.next_power_of_two() >> 1;
-        let (a_lo, a_hi) = self.a.split_at(half);
-        let (b_lo, b_hi) = self.b.split_at(half);
-
-        // a_lo may be longer than a_hi (non-pow2 input, implicit zero padding).
-        let paired = a_hi.len();
-        let a_lo_paired = &a_lo[..paired];
-        let b_lo_paired = &b_lo[..paired];
-        let a_lo_tail = &a_lo[paired..];
-        let b_lo_tail = &b_lo[paired..];
-
-        let mut q0 = F::ZERO;
-        let mut q_inf = F::ZERO;
-        for i in 0..paired {
-            let al = a_lo_paired[i];
-            let ah = a_hi[i];
-            let bl = b_lo_paired[i];
-            let bh = b_hi[i];
-            q0 += al * bl;
-            q_inf += (ah - al) * (bh - bl);
-        }
-
-        // Tail (hi implicitly zero): ah = bh = 0, so
-        //   q(0)  += al·bl
-        //   q(∞)  += (0 − al)·(0 − bl) = al·bl
-        let tail_dot: F = a_lo_tail.iter().zip(b_lo_tail).map(|(&a, &b)| a * b).sum();
-        q0 += tail_dot;
-        q_inf += tail_dot;
-
+        let (q0, q_inf) = if let Some(w) = challenge {
+            ip::fused_fold_and_compute_polynomial(&mut self.a, &mut self.b, w)
+        } else {
+            ip::compute_sumcheck_polynomial(&self.a, &self.b)
+        };
         vec![q0, q_inf]
     }
 


### PR DESCRIPTION
##Summary

Two small performance fixes to the per-round hot paths. All tests pass unchanged.

1. InnerProductProver::round now delegates to the fused kernel
2. shrink_to_fit removed from the remaining per-round folds, aligning with documented policy. At 2^24 the realloc was costing ~33% of the fold. 

## Performance

Apple M-series (aarch64/NEON), default features, cargo bench --bench sumcheck, criterion. Baseline = current main (9e55dc3).

| bench | size | main | this PR | change |
|---|---|---|---|---|
| `inner_product/F64` | 2^20 | 4.43 ms | 2.12 ms | **−52%** |
| `inner_product/F64` | 2^24 | 66.3 ms | 21.7 ms | **−67% (3.05×)** |
| `inner_product/F64Ext3` | 2^16 | 2.57 ms | 1.17 ms | **−54%** |
| `inner_product/F64Ext3` | 2^20 | 34.6 ms | 9.97 ms | **−72%** |
| `inner_product/F64Ext3` | 2^24 | 542 ms | 140 ms | **−74% (3.9×)** |
| `fold/F64` | 2^20 | 597 µs | 532 µs | **−8%** |
| `fold/F64` | 2^24 | 13.9 ms | 9.63 ms | **−33% (1.5×)** |

Notes:
A single fold pass over 2^24 (13.9 ms) was slower than an entire 24-round multilinear sumcheck (9.8 ms) — the shrink realloc, not the arithmetic, was the cost.

## Verification
cargo test --all-features (128 tests, includes the adversarial verifier suite and legacy equality tests), cargo clippy --all-features -- -D warnings, cargo fmt --check — all